### PR TITLE
port tests to foundry

### DIFF
--- a/src/FlashMintLib.sol
+++ b/src/FlashMintLib.sol
@@ -59,7 +59,9 @@ library FlashMintLib {
         // calculate amount of dai we need
         uint256 requiredDAI;
         {
-            requiredDAI = _toDAI(amount, token) * COLLAT_RATIO_PRECISION / collatRatioDAI;
+            requiredDAI =
+                (_toDAI(amount, token) * COLLAT_RATIO_PRECISION) /
+                collatRatioDAI;
 
             uint256 requiredDAIToCloseLTVGap = 0;
             if (depositToCloseLTVGap > 0) {
@@ -71,9 +73,10 @@ library FlashMintLib {
             if (requiredDAI > _maxLiquidity) {
                 requiredDAI = _maxLiquidity;
                 // NOTE: if we cap amountDAI, we reduce amountToken we are taking too
-                amount = _fromDAI(requiredDAI - requiredDAIToCloseLTVGap,
-                    token
-                ) * collatRatioDAI / COLLAT_RATIO_PRECISION;
+                amount =
+                    (_fromDAI(requiredDAI - requiredDAIToCloseLTVGap, token) *
+                        collatRatioDAI) /
+                    COLLAT_RATIO_PRECISION;
             }
         }
 
@@ -81,8 +84,10 @@ library FlashMintLib {
         uint256 _fee = IERC3156FlashLender(LENDER).flashFee(dai, requiredDAI);
         // Check that fees have not been increased without us knowing
         require(_fee == 0);
-        uint256 _allowance =
-            IERC20(dai).allowance(address(this), address(LENDER));
+        uint256 _allowance = IERC20(dai).allowance(
+            address(this),
+            address(LENDER)
+        );
         if (_allowance < requiredDAI) {
             IERC20(dai).approve(address(LENDER), 0);
             IERC20(dai).approve(address(LENDER), type(uint256).max);
@@ -193,7 +198,9 @@ library FlashMintLib {
 
         if (asset == WETH) {
             return
-                _amount * uint256(10)**uint256(IOptionalERC20(dai).decimals()) / _priceOracle().getAssetPrice(dai);
+                (_amount *
+                    uint256(10)**uint256(IOptionalERC20(dai).decimals())) /
+                _priceOracle().getAssetPrice(dai);
         }
 
         address[] memory tokens = new address[](2);
@@ -201,9 +208,9 @@ library FlashMintLib {
         tokens[1] = dai;
         uint256[] memory prices = _priceOracle().getAssetsPrices(tokens);
 
-        uint256 ethPrice =
-            _amount * prices[0] / uint256(10)**uint256(IOptionalERC20(asset).decimals());
-        return ethPrice * DAI_DECIMALS / prices[1];
+        uint256 ethPrice = (_amount * prices[0]) /
+            uint256(10)**uint256(IOptionalERC20(asset).decimals());
+        return (ethPrice * DAI_DECIMALS) / prices[1];
     }
 
     function _fromDAI(uint256 _amount, address asset)
@@ -220,7 +227,8 @@ library FlashMintLib {
 
         if (asset == WETH) {
             return
-                _amount * _priceOracle().getAssetPrice(dai) / uint256(10)**uint256(IOptionalERC20(dai).decimals());
+                (_amount * _priceOracle().getAssetPrice(dai)) /
+                uint256(10)**uint256(IOptionalERC20(dai).decimals());
         }
 
         address[] memory tokens = new address[](2);
@@ -228,10 +236,12 @@ library FlashMintLib {
         tokens[1] = dai;
         uint256[] memory prices = _priceOracle().getAssetsPrices(tokens);
 
-        uint256 ethPrice = _amount * prices[1] / DAI_DECIMALS;
+        uint256 ethPrice = (_amount * prices[1]) / DAI_DECIMALS;
 
         return
-            ethPrice * uint256(10)**uint256(IOptionalERC20(asset).decimals()) / prices[0];
+            (ethPrice *
+                uint256(10)**uint256(IOptionalERC20(asset).decimals())) /
+            prices[0];
     }
 
     function maxLiquidity() public view returns (uint256) {

--- a/src/interfaces/Vault.sol
+++ b/src/interfaces/Vault.sol
@@ -136,8 +136,16 @@ interface IVault is IERC20 {
 
     function setEmergencyShutdown(bool active) external;
 
+    function setManagementFee(uint256 fee) external;
+
     function updateStrategyDebtRatio(address strategy, uint256 debtRatio)
         external;
+
+    function withdraw(
+        uint256 maxShare,
+        address recipient,
+        uint256 maxLoss
+    ) external;
 
     /**
      * View the governance address of the Vault to assert privileged functions

--- a/src/interfaces/Vault.sol
+++ b/src/interfaces/Vault.sol
@@ -99,6 +99,8 @@ interface IVault is IERC20 {
      */
     function debtOutstanding() external view returns (uint256);
 
+    function debtOutstanding(address _strategy) external view returns (uint256);
+
     /**
      * View how much the Vault expect this Strategy to return at the current
      * block, based on its present performance (since its last report). Can be

--- a/src/interfaces/aave/ILendingPool.sol
+++ b/src/interfaces/aave/ILendingPool.sol
@@ -2,9 +2,7 @@
 pragma solidity 0.8.12;
 pragma experimental ABIEncoderV2;
 
-import {
-    ILendingPoolAddressesProvider
-} from "./ILendingPoolAddressesProvider.sol";
+import {ILendingPoolAddressesProvider} from "./ILendingPoolAddressesProvider.sol";
 import {DataTypes} from "../../libraries/aave/DataTypes.sol";
 
 interface ILendingPool {

--- a/src/interfaces/aave/IProtocolDataProvider.sol
+++ b/src/interfaces/aave/IProtocolDataProvider.sol
@@ -2,9 +2,7 @@
 pragma solidity 0.8.12;
 pragma experimental ABIEncoderV2;
 
-import {
-    ILendingPoolAddressesProvider
-} from "./ILendingPoolAddressesProvider.sol";
+import {ILendingPoolAddressesProvider} from "./ILendingPoolAddressesProvider.sol";
 
 interface IProtocolDataProvider {
     struct TokenData {

--- a/src/interfaces/compound/CErc20I.sol
+++ b/src/interfaces/compound/CErc20I.sol
@@ -14,7 +14,9 @@ interface CErc20I is CTokenI {
 
     function repayBorrow(uint256 repayAmount) external returns (uint256);
 
-    function repayBorrowBehalf(address borrower, uint256 repayAmount) external returns (uint256);
+    function repayBorrowBehalf(address borrower, uint256 repayAmount)
+        external
+        returns (uint256);
 
     function liquidateBorrow(
         address borrower,

--- a/src/interfaces/compound/CEtherI.sol
+++ b/src/interfaces/compound/CEtherI.sol
@@ -8,10 +8,13 @@ interface CEtherI is CTokenI {
 
     function redeem(uint256 redeemTokens) external returns (uint256);
 
-    function liquidateBorrow(address borrower, CTokenI cTokenCollateral) external payable;
+    function liquidateBorrow(address borrower, CTokenI cTokenCollateral)
+        external
+        payable;
 
-    function borrow(uint256 borrowAmount) external returns (uint);
+    function borrow(uint256 borrowAmount) external returns (uint256);
 
     function mint() external payable;
+
     function repayBorrow() external payable;
 }

--- a/src/interfaces/compound/CTokenI.sol
+++ b/src/interfaces/compound/CTokenI.sol
@@ -8,7 +8,12 @@ interface CTokenI {
     /**
      * @notice Event emitted when interest is accrued
      */
-    event AccrueInterest(uint256 cashPrior, uint256 interestAccumulated, uint256 borrowIndex, uint256 totalBorrows);
+    event AccrueInterest(
+        uint256 cashPrior,
+        uint256 interestAccumulated,
+        uint256 borrowIndex,
+        uint256 totalBorrows
+    );
 
     /**
      * @notice Event emitted when tokens are minted
@@ -23,17 +28,34 @@ interface CTokenI {
     /**
      * @notice Event emitted when underlying is borrowed
      */
-    event Borrow(address borrower, uint256 borrowAmount, uint256 accountBorrows, uint256 totalBorrows);
+    event Borrow(
+        address borrower,
+        uint256 borrowAmount,
+        uint256 accountBorrows,
+        uint256 totalBorrows
+    );
 
     /**
      * @notice Event emitted when a borrow is repaid
      */
-    event RepayBorrow(address payer, address borrower, uint256 repayAmount, uint256 accountBorrows, uint256 totalBorrows);
+    event RepayBorrow(
+        address payer,
+        address borrower,
+        uint256 repayAmount,
+        uint256 accountBorrows,
+        uint256 totalBorrows
+    );
 
     /**
      * @notice Event emitted when a borrow is liquidated
      */
-    event LiquidateBorrow(address liquidator, address borrower, uint256 repayAmount, address cTokenCollateral, uint256 seizeTokens);
+    event LiquidateBorrow(
+        address liquidator,
+        address borrower,
+        uint256 repayAmount,
+        address cTokenCollateral,
+        uint256 seizeTokens
+    );
 
     /*** Admin Events ***/
 
@@ -50,17 +72,28 @@ interface CTokenI {
     /**
      * @notice Event emitted when the reserve factor is changed
      */
-    event NewReserveFactor(uint256 oldReserveFactorMantissa, uint256 newReserveFactorMantissa);
+    event NewReserveFactor(
+        uint256 oldReserveFactorMantissa,
+        uint256 newReserveFactorMantissa
+    );
 
     /**
      * @notice Event emitted when the reserves are added
      */
-    event ReservesAdded(address benefactor, uint256 addAmount, uint256 newTotalReserves);
+    event ReservesAdded(
+        address benefactor,
+        uint256 addAmount,
+        uint256 newTotalReserves
+    );
 
     /**
      * @notice Event emitted when the reserves are reduced
      */
-    event ReservesReduced(address admin, uint256 reduceAmount, uint256 newTotalReserves);
+    event ReservesReduced(
+        address admin,
+        uint256 reduceAmount,
+        uint256 newTotalReserves
+    );
 
     /**
      * @notice EIP20 Transfer event
@@ -70,7 +103,11 @@ interface CTokenI {
     /**
      * @notice EIP20 Approval event
      */
-    event Approval(address indexed owner, address indexed spender, uint256 amount);
+    event Approval(
+        address indexed owner,
+        address indexed spender,
+        uint256 amount
+    );
 
     /**
      * @notice Failure event
@@ -87,7 +124,10 @@ interface CTokenI {
 
     function approve(address spender, uint256 amount) external returns (bool);
 
-    function allowance(address owner, address spender) external view returns (uint256);
+    function allowance(address owner, address spender)
+        external
+        view
+        returns (uint256);
 
     function balanceOf(address owner) external view returns (uint256);
 
@@ -111,7 +151,10 @@ interface CTokenI {
 
     function borrowBalanceCurrent(address account) external returns (uint256);
 
-    function borrowBalanceStored(address account) external view returns (uint256);
+    function borrowBalanceStored(address account)
+        external
+        view
+        returns (uint256);
 
     function exchangeRateCurrent() external returns (uint256);
 

--- a/src/interfaces/compound/CarefulMath.sol
+++ b/src/interfaces/compound/CarefulMath.sol
@@ -11,12 +11,21 @@ contract CarefulMath {
     /**
      * @dev Possible error codes that we can return
      */
-    enum MathError {NO_ERROR, DIVISION_BY_ZERO, INTEGER_OVERFLOW, INTEGER_UNDERFLOW}
+    enum MathError {
+        NO_ERROR,
+        DIVISION_BY_ZERO,
+        INTEGER_OVERFLOW,
+        INTEGER_UNDERFLOW
+    }
 
     /**
      * @dev Multiplies two numbers, returns an error on overflow.
      */
-    function mulUInt(uint256 a, uint256 b) internal pure returns (MathError, uint256) {
+    function mulUInt(uint256 a, uint256 b)
+        internal
+        pure
+        returns (MathError, uint256)
+    {
         if (a == 0) {
             return (MathError.NO_ERROR, 0);
         }
@@ -33,7 +42,11 @@ contract CarefulMath {
     /**
      * @dev Integer division of two numbers, truncating the quotient.
      */
-    function divUInt(uint256 a, uint256 b) internal pure returns (MathError, uint256) {
+    function divUInt(uint256 a, uint256 b)
+        internal
+        pure
+        returns (MathError, uint256)
+    {
         if (b == 0) {
             return (MathError.DIVISION_BY_ZERO, 0);
         }
@@ -44,7 +57,11 @@ contract CarefulMath {
     /**
      * @dev Subtracts two numbers, returns an error on overflow (i.e. if subtrahend is greater than minuend).
      */
-    function subUInt(uint256 a, uint256 b) internal pure returns (MathError, uint256) {
+    function subUInt(uint256 a, uint256 b)
+        internal
+        pure
+        returns (MathError, uint256)
+    {
         if (b <= a) {
             return (MathError.NO_ERROR, a - b);
         } else {
@@ -55,7 +72,11 @@ contract CarefulMath {
     /**
      * @dev Adds two numbers, returns an error on overflow.
      */
-    function addUInt(uint256 a, uint256 b) internal pure returns (MathError, uint256) {
+    function addUInt(uint256 a, uint256 b)
+        internal
+        pure
+        returns (MathError, uint256)
+    {
         uint256 c = a + b;
 
         if (c >= a) {

--- a/src/interfaces/compound/ComptrollerI.sol
+++ b/src/interfaces/compound/ComptrollerI.sol
@@ -5,7 +5,9 @@ pragma experimental ABIEncoderV2;
 import "./CTokenI.sol";
 
 interface ComptrollerI {
-    function enterMarkets(address[] calldata cTokens) external returns (uint256[] memory);
+    function enterMarkets(address[] calldata cTokens)
+        external
+        returns (uint256[] memory);
 
     function exitMarket(address cToken) external returns (uint256);
 

--- a/src/interfaces/compound/Exponential.sol
+++ b/src/interfaces/compound/Exponential.sol
@@ -29,7 +29,11 @@ contract Exponential is CarefulMath {
      *      Note: Returns an error if (`num` * 10e18) > MAX_INT,
      *            or if `denom` is zero.
      */
-    function getExp(uint256 num, uint256 denom) internal pure returns (MathError, Exp memory) {
+    function getExp(uint256 num, uint256 denom)
+        internal
+        pure
+        returns (MathError, Exp memory)
+    {
         (MathError err0, uint256 scaledNumerator) = mulUInt(num, expScale);
         if (err0 != MathError.NO_ERROR) {
             return (err0, Exp({mantissa: 0}));
@@ -46,7 +50,11 @@ contract Exponential is CarefulMath {
     /**
      * @dev Adds two exponentials, returning a new exponential.
      */
-    function addExp(Exp memory a, Exp memory b) internal pure returns (MathError, Exp memory) {
+    function addExp(Exp memory a, Exp memory b)
+        internal
+        pure
+        returns (MathError, Exp memory)
+    {
         (MathError error, uint256 result) = addUInt(a.mantissa, b.mantissa);
 
         return (error, Exp({mantissa: result}));
@@ -55,7 +63,11 @@ contract Exponential is CarefulMath {
     /**
      * @dev Subtracts two exponentials, returning a new exponential.
      */
-    function subExp(Exp memory a, Exp memory b) internal pure returns (MathError, Exp memory) {
+    function subExp(Exp memory a, Exp memory b)
+        internal
+        pure
+        returns (MathError, Exp memory)
+    {
         (MathError error, uint256 result) = subUInt(a.mantissa, b.mantissa);
 
         return (error, Exp({mantissa: result}));
@@ -64,7 +76,11 @@ contract Exponential is CarefulMath {
     /**
      * @dev Multiply an Exp by a scalar, returning a new Exp.
      */
-    function mulScalar(Exp memory a, uint256 scalar) internal pure returns (MathError, Exp memory) {
+    function mulScalar(Exp memory a, uint256 scalar)
+        internal
+        pure
+        returns (MathError, Exp memory)
+    {
         (MathError err0, uint256 scaledMantissa) = mulUInt(a.mantissa, scalar);
         if (err0 != MathError.NO_ERROR) {
             return (err0, Exp({mantissa: 0}));
@@ -76,7 +92,11 @@ contract Exponential is CarefulMath {
     /**
      * @dev Multiply an Exp by a scalar, then truncate to return an unsigned integer.
      */
-    function mulScalarTruncate(Exp memory a, uint256 scalar) internal pure returns (MathError, uint256) {
+    function mulScalarTruncate(Exp memory a, uint256 scalar)
+        internal
+        pure
+        returns (MathError, uint256)
+    {
         (MathError err, Exp memory product) = mulScalar(a, scalar);
         if (err != MathError.NO_ERROR) {
             return (err, 0);
@@ -104,8 +124,15 @@ contract Exponential is CarefulMath {
     /**
      * @dev Divide an Exp by a scalar, returning a new Exp.
      */
-    function divScalar(Exp memory a, uint256 scalar) internal pure returns (MathError, Exp memory) {
-        (MathError err0, uint256 descaledMantissa) = divUInt(a.mantissa, scalar);
+    function divScalar(Exp memory a, uint256 scalar)
+        internal
+        pure
+        returns (MathError, Exp memory)
+    {
+        (MathError err0, uint256 descaledMantissa) = divUInt(
+            a.mantissa,
+            scalar
+        );
         if (err0 != MathError.NO_ERROR) {
             return (err0, Exp({mantissa: 0}));
         }
@@ -116,7 +143,11 @@ contract Exponential is CarefulMath {
     /**
      * @dev Divide a scalar by an Exp, returning a new Exp.
      */
-    function divScalarByExp(uint256 scalar, Exp memory divisor) internal pure returns (MathError, Exp memory) {
+    function divScalarByExp(uint256 scalar, Exp memory divisor)
+        internal
+        pure
+        returns (MathError, Exp memory)
+    {
         /*
           We are doing this as:
           getExp(mulUInt(expScale, scalar), divisor.mantissa)
@@ -135,7 +166,11 @@ contract Exponential is CarefulMath {
     /**
      * @dev Divide a scalar by an Exp, then truncate to return an unsigned integer.
      */
-    function divScalarByExpTruncate(uint256 scalar, Exp memory divisor) internal pure returns (MathError, uint256) {
+    function divScalarByExpTruncate(uint256 scalar, Exp memory divisor)
+        internal
+        pure
+        returns (MathError, uint256)
+    {
         (MathError err, Exp memory fraction) = divScalarByExp(scalar, divisor);
         if (err != MathError.NO_ERROR) {
             return (err, 0);
@@ -147,8 +182,15 @@ contract Exponential is CarefulMath {
     /**
      * @dev Multiplies two exponentials, returning a new exponential.
      */
-    function mulExp(Exp memory a, Exp memory b) internal pure returns (MathError, Exp memory) {
-        (MathError err0, uint256 doubleScaledProduct) = mulUInt(a.mantissa, b.mantissa);
+    function mulExp(Exp memory a, Exp memory b)
+        internal
+        pure
+        returns (MathError, Exp memory)
+    {
+        (MathError err0, uint256 doubleScaledProduct) = mulUInt(
+            a.mantissa,
+            b.mantissa
+        );
         if (err0 != MathError.NO_ERROR) {
             return (err0, Exp({mantissa: 0}));
         }
@@ -156,12 +198,18 @@ contract Exponential is CarefulMath {
         // We add half the scale before dividing so that we get rounding instead of truncation.
         //  See "Listing 6" and text above it at https://accu.org/index.php/journals/1717
         // Without this change, a result like 6.6...e-19 will be truncated to 0 instead of being rounded to 1e-18.
-        (MathError err1, uint256 doubleScaledProductWithHalfScale) = addUInt(halfExpScale, doubleScaledProduct);
+        (MathError err1, uint256 doubleScaledProductWithHalfScale) = addUInt(
+            halfExpScale,
+            doubleScaledProduct
+        );
         if (err1 != MathError.NO_ERROR) {
             return (err1, Exp({mantissa: 0}));
         }
 
-        (MathError err2, uint256 product) = divUInt(doubleScaledProductWithHalfScale, expScale);
+        (MathError err2, uint256 product) = divUInt(
+            doubleScaledProductWithHalfScale,
+            expScale
+        );
         // The only error `div` can return is MathError.DIVISION_BY_ZERO but we control `expScale` and it is not zero.
         assert(err2 == MathError.NO_ERROR);
 
@@ -171,7 +219,11 @@ contract Exponential is CarefulMath {
     /**
      * @dev Multiplies two exponentials given their mantissas, returning a new exponential.
      */
-    function mulExp(uint256 a, uint256 b) internal pure returns (MathError, Exp memory) {
+    function mulExp(uint256 a, uint256 b)
+        internal
+        pure
+        returns (MathError, Exp memory)
+    {
         return mulExp(Exp({mantissa: a}), Exp({mantissa: b}));
     }
 
@@ -195,7 +247,11 @@ contract Exponential is CarefulMath {
      *     (a/scale) / (b/scale) = (a/scale) * (scale/b) = a/b,
      *  which we can scale as an Exp by calling getExp(a.mantissa, b.mantissa)
      */
-    function divExp(Exp memory a, Exp memory b) internal pure returns (MathError, Exp memory) {
+    function divExp(Exp memory a, Exp memory b)
+        internal
+        pure
+        returns (MathError, Exp memory)
+    {
         return getExp(a.mantissa, b.mantissa);
     }
 
@@ -211,21 +267,33 @@ contract Exponential is CarefulMath {
     /**
      * @dev Checks if first Exp is less than second Exp.
      */
-    function lessThanExp(Exp memory left, Exp memory right) internal pure returns (bool) {
+    function lessThanExp(Exp memory left, Exp memory right)
+        internal
+        pure
+        returns (bool)
+    {
         return left.mantissa < right.mantissa;
     }
 
     /**
      * @dev Checks if left Exp <= right Exp.
      */
-    function lessThanOrEqualExp(Exp memory left, Exp memory right) internal pure returns (bool) {
+    function lessThanOrEqualExp(Exp memory left, Exp memory right)
+        internal
+        pure
+        returns (bool)
+    {
         return left.mantissa <= right.mantissa;
     }
 
     /**
      * @dev Checks if left Exp > right Exp.
      */
-    function greaterThanExp(Exp memory left, Exp memory right) internal pure returns (bool) {
+    function greaterThanExp(Exp memory left, Exp memory right)
+        internal
+        pure
+        returns (bool)
+    {
         return left.mantissa > right.mantissa;
     }
 
@@ -236,21 +304,37 @@ contract Exponential is CarefulMath {
         return value.mantissa == 0;
     }
 
-    function safe224(uint256 n, string memory errorMessage) internal pure returns (uint224) {
+    function safe224(uint256 n, string memory errorMessage)
+        internal
+        pure
+        returns (uint224)
+    {
         require(n < 2**224, errorMessage);
         return uint224(n);
     }
 
-    function safe32(uint256 n, string memory errorMessage) internal pure returns (uint32) {
+    function safe32(uint256 n, string memory errorMessage)
+        internal
+        pure
+        returns (uint32)
+    {
         require(n < 2**32, errorMessage);
         return uint32(n);
     }
 
-    function add_(Exp memory a, Exp memory b) internal pure returns (Exp memory) {
+    function add_(Exp memory a, Exp memory b)
+        internal
+        pure
+        returns (Exp memory)
+    {
         return Exp({mantissa: add_(a.mantissa, b.mantissa)});
     }
 
-    function add_(Double memory a, Double memory b) internal pure returns (Double memory) {
+    function add_(Double memory a, Double memory b)
+        internal
+        pure
+        returns (Double memory)
+    {
         return Double({mantissa: add_(a.mantissa, b.mantissa)});
     }
 
@@ -268,11 +352,19 @@ contract Exponential is CarefulMath {
         return c;
     }
 
-    function sub_(Exp memory a, Exp memory b) internal pure returns (Exp memory) {
+    function sub_(Exp memory a, Exp memory b)
+        internal
+        pure
+        returns (Exp memory)
+    {
         return Exp({mantissa: sub_(a.mantissa, b.mantissa)});
     }
 
-    function sub_(Double memory a, Double memory b) internal pure returns (Double memory) {
+    function sub_(Double memory a, Double memory b)
+        internal
+        pure
+        returns (Double memory)
+    {
         return Double({mantissa: sub_(a.mantissa, b.mantissa)});
     }
 
@@ -289,7 +381,11 @@ contract Exponential is CarefulMath {
         return a - b;
     }
 
-    function mul_(Exp memory a, Exp memory b) internal pure returns (Exp memory) {
+    function mul_(Exp memory a, Exp memory b)
+        internal
+        pure
+        returns (Exp memory)
+    {
         return Exp({mantissa: mul_(a.mantissa, b.mantissa) / expScale});
     }
 
@@ -301,11 +397,19 @@ contract Exponential is CarefulMath {
         return mul_(a, b.mantissa) / expScale;
     }
 
-    function mul_(Double memory a, Double memory b) internal pure returns (Double memory) {
+    function mul_(Double memory a, Double memory b)
+        internal
+        pure
+        returns (Double memory)
+    {
         return Double({mantissa: mul_(a.mantissa, b.mantissa) / doubleScale});
     }
 
-    function mul_(Double memory a, uint256 b) internal pure returns (Double memory) {
+    function mul_(Double memory a, uint256 b)
+        internal
+        pure
+        returns (Double memory)
+    {
         return Double({mantissa: mul_(a.mantissa, b)});
     }
 
@@ -330,7 +434,11 @@ contract Exponential is CarefulMath {
         return c;
     }
 
-    function div_(Exp memory a, Exp memory b) internal pure returns (Exp memory) {
+    function div_(Exp memory a, Exp memory b)
+        internal
+        pure
+        returns (Exp memory)
+    {
         return Exp({mantissa: div_(mul_(a.mantissa, expScale), b.mantissa)});
     }
 
@@ -342,11 +450,20 @@ contract Exponential is CarefulMath {
         return div_(mul_(a, expScale), b.mantissa);
     }
 
-    function div_(Double memory a, Double memory b) internal pure returns (Double memory) {
-        return Double({mantissa: div_(mul_(a.mantissa, doubleScale), b.mantissa)});
+    function div_(Double memory a, Double memory b)
+        internal
+        pure
+        returns (Double memory)
+    {
+        return
+            Double({mantissa: div_(mul_(a.mantissa, doubleScale), b.mantissa)});
     }
 
-    function div_(Double memory a, uint256 b) internal pure returns (Double memory) {
+    function div_(Double memory a, uint256 b)
+        internal
+        pure
+        returns (Double memory)
+    {
         return Double({mantissa: div_(a.mantissa, b)});
     }
 
@@ -367,7 +484,11 @@ contract Exponential is CarefulMath {
         return a / b;
     }
 
-    function fraction(uint256 a, uint256 b) internal pure returns (Double memory) {
+    function fraction(uint256 a, uint256 b)
+        internal
+        pure
+        returns (Double memory)
+    {
         return Double({mantissa: div_(mul_(a, doubleScale), b)});
     }
 }

--- a/src/interfaces/dai/IERC3156FlashBorrower.sol
+++ b/src/interfaces/dai/IERC3156FlashBorrower.sol
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.6.12;
+pragma solidity >=0.8.12;
 
 interface IERC3156FlashBorrower {
     /**

--- a/src/interfaces/dai/IERC3156FlashLender.sol
+++ b/src/interfaces/dai/IERC3156FlashLender.sol
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-pragma solidity >=0.6.12;
+pragma solidity >=0.8.12;
 
 import "./IERC3156FlashBorrower.sol";
 

--- a/src/interfaces/uniswap/IUni.sol
+++ b/src/interfaces/uniswap/IUni.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0
 pragma solidity 0.8.12;
 
-interface IUni{
-    function getAmountsOut(
-        uint256 amountIn,
-        address[] calldata path
-    ) external view returns (uint256[] memory amounts);
+interface IUni {
+    function getAmountsOut(uint256 amountIn, address[] calldata path)
+        external
+        view
+        returns (uint256[] memory amounts);
 
     function swapExactTokensForTokens(
         uint256 amountIn,

--- a/src/interfaces/uniswap/IUniswapV3SwapCallback.sol
+++ b/src/interfaces/uniswap/IUniswapV3SwapCallback.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
-pragma solidity >=0.5.0;
+pragma solidity >=0.8.12;
 
 /// @title Callback for IUniswapV3PoolActions#swap
 /// @notice Any contract that calls IUniswapV3PoolActions#swap must implement this interface

--- a/src/libraries/aave/DataTypes.sol
+++ b/src/libraries/aave/DataTypes.sol
@@ -45,5 +45,9 @@ library DataTypes {
         uint256 data;
     }
 
-    enum InterestRateMode {NONE, STABLE, VARIABLE}
+    enum InterestRateMode {
+        NONE,
+        STABLE,
+        VARIABLE
+    }
 }

--- a/src/test/StrategyAirdrop.t.sol
+++ b/src/test/StrategyAirdrop.t.sol
@@ -10,9 +10,7 @@ contract StrategyAirdrop is StrategyFixture {
     }
 
     function testAirdrop(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), user, _amount);
 
         // Deposit to the vault

--- a/src/test/StrategyAirdrop.t.sol
+++ b/src/test/StrategyAirdrop.t.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.12;
+
+import {StrategyParams} from "../interfaces/Vault.sol";
+import {StrategyFixture} from "./utils/StrategyFixture.sol";
+
+contract StrategyAirdrop is StrategyFixture {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    function testAirdrop(uint256 _amount) public {
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), user, _amount);
+
+        // Deposit to the vault
+        actions.userDeposit(user, vault, want, _amount);
+
+        // Harvest 1: Send funds through the strategy
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        uint256 totalAssets = strategy.estimatedTotalAssets();
+        assertRelApproxEq(totalAssets, _amount, DELTA);
+
+        // we airdrop tokens to strategy
+        uint256 airdropAmount = (_amount * 10) / 100;
+        tip(address(want), whale, airdropAmount);
+        vm_std_cheats.prank(whale);
+        want.transfer(address(strategy), airdropAmount);
+
+        // check that estimatedTotalAssets estimates correctly
+        assertRelApproxEq(
+            strategy.estimatedTotalAssets(),
+            (totalAssets + airdropAmount + strategy.estimatedRewardsInWant()),
+            DELTA
+        );
+
+        uint256 beforePps = vault.pricePerShare();
+        // Harvest 2: Realize profit
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        skip(6 hours);
+        uint256 profit = want.balanceOf(address(vault));
+        StrategyParams memory sp = vault.strategies(address(strategy));
+        assertGt(sp.totalDebt + profit, _amount);
+        assertGt(vault.pricePerShare(), beforePps);
+    }
+}

--- a/src/test/StrategyClone.t.sol
+++ b/src/test/StrategyClone.t.sol
@@ -24,10 +24,6 @@ contract StrategyClone is StrategyFixture {
         assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
 
         vm_std_cheats.prank(strategist);
-        LevAaveFactory levAaveFactory = LevAaveFactory(
-            deployLevAaveFactory(address(vault))
-        );
-        vm_std_cheats.prank(strategist);
         Strategy clonedStrategy = Strategy(
             levAaveFactory.cloneLevAave(address(vault))
         );

--- a/src/test/StrategyClone.t.sol
+++ b/src/test/StrategyClone.t.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.12;
+
+import {LevAaveFactory} from "../LevAaveFactory.sol";
+import {Strategy} from "../Strategy.sol";
+import {StrategyFixture} from "./utils/StrategyFixture.sol";
+
+contract StrategyClone is StrategyFixture {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    function testClone(uint256 _amount) public {
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), user, _amount);
+
+        uint256 balanceBefore = want.balanceOf(user);
+        actions.userDeposit(user, vault, want, _amount);
+
+        // harvest
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+
+        vm_std_cheats.prank(strategist);
+        LevAaveFactory levAaveFactory = LevAaveFactory(
+            deployLevAaveFactory(address(vault))
+        );
+        vm_std_cheats.prank(strategist);
+        Strategy clonedStrategy = Strategy(
+            levAaveFactory.cloneLevAave(address(vault))
+        );
+
+        // free funds from old strategy
+        vm_std_cheats.prank(gov);
+        vault.revokeStrategy(address(strategy));
+        skip(1);
+        vm_std_cheats.prank(gov);
+        strategy.harvest();
+        assertLt(strategy.estimatedTotalAssets(), strategy.minWant());
+
+        // take funds to new strategy
+        vm_std_cheats.prank(gov);
+        vault.addStrategy(
+            address(clonedStrategy),
+            10_000,
+            0,
+            type(uint256).max,
+            1_000
+        );
+        tip(address(weth), whale, 1e6);
+        vm_std_cheats.prank(whale);
+        weth.transfer(address(clonedStrategy), 1e6);
+        skip(1);
+        vm_std_cheats.prank(gov);
+        clonedStrategy.harvest();
+        assertRelApproxEq(
+            clonedStrategy.estimatedTotalAssets(),
+            _amount,
+            DELTA
+        );
+    }
+}

--- a/src/test/StrategyClone.t.sol
+++ b/src/test/StrategyClone.t.sol
@@ -11,9 +11,7 @@ contract StrategyClone is StrategyFixture {
     }
 
     function testClone(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), user, _amount);
 
         uint256 balanceBefore = want.balanceOf(user);

--- a/src/test/StrategyDeleverage.t.sol
+++ b/src/test/StrategyDeleverage.t.sol
@@ -1,0 +1,182 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.12;
+
+import {StrategyParams} from "../interfaces/Vault.sol";
+import {StrategyFixture} from "./utils/StrategyFixture.sol";
+
+contract StrategyDeleverage is StrategyFixture {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    function testDeleverageToZero(uint256 _amount) public {
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
+        tip(address(want), user, _amount);
+
+        // Deposit to the vault and harvest
+        actions.userDeposit(user, vault, want, _amount);
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+
+        skip(1 weeks);
+        utils.strategyStatus(vault, strategy);
+
+        vm_std_cheats.prank(gov);
+        vault.revokeStrategy(address(strategy));
+        uint256 i = 0;
+        while (vault.debtOutstanding(address(strategy)) > 0 && i < 5) {
+            skip(1);
+            vm_std_cheats.prank(strategist);
+            strategy.harvest();
+            utils.strategyStatus(vault, strategy);
+            i++;
+        }
+
+        skip(6 hours);
+        utils.strategyStatus(vault, strategy);
+        assertLt(strategy.estimatedTotalAssets(), strategy.minWant());
+
+        StrategyParams memory sp = vault.strategies(address(strategy));
+        assertRelApproxEq(sp.totalLoss, 0, DELTA);
+    }
+
+    function testLargeDeleverageParameterChange(uint256 _amount) public {
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
+        tip(address(want), user, _amount);
+
+        // Deposit to the vault and harvest
+        actions.userDeposit(user, vault, want, _amount);
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+
+        skip(1 weeks);
+
+        vm_std_cheats.startPrank(gov);
+        strategy.setCollateralTargets(
+            strategy.targetCollatRatio() / 2,
+            strategy.maxCollatRatio(),
+            strategy.maxBorrowCollatRatio(),
+            strategy.daiBorrowCollatRatio()
+        );
+        vm_std_cheats.stopPrank();
+
+        utils.strategyStatus(vault, strategy);
+
+        uint256 i = 0;
+        while (
+            !_assertRelApproxEq(
+                strategy.getCurrentCollatRatio(),
+                strategy.targetCollatRatio(),
+                DELTA
+            )
+        ) {
+            skip(1);
+            vm_std_cheats.prank(strategist);
+            strategy.harvest();
+            utils.strategyStatus(vault, strategy);
+            i++;
+        }
+
+        assertRelApproxEq(
+            strategy.getCurrentCollatRatio(),
+            strategy.targetCollatRatio(),
+            DELTA
+        );
+        skip(6 hours);
+        utils.strategyStatus(vault, strategy);
+
+        StrategyParams memory sp = vault.strategies(address(strategy));
+        assertRelApproxEq(sp.totalLoss, 0, DELTA);
+    }
+
+    function testLargeManualDeleverageToZero(uint256 _amount) public {
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
+        tip(address(want), user, _amount);
+
+        // Deposit to the vault and harvest
+        actions.userDeposit(user, vault, want, _amount);
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+
+        skip(1 weeks);
+        utils.strategyStatus(vault, strategy);
+
+        uint256 i = 0;
+        while (strategy.getCurrentSupply() > strategy.minWant()) {
+            skip(1);
+
+            (uint256 deposit, uint256 borrow) = strategy.getCurrentPosition();
+            uint256 theoMinDeposit = borrow * 10**18 / strategy.maxCollatRatio();
+            uint256 stepSize = _min(uint256(deposit - theoMinDeposit), borrow);
+
+            vm_std_cheats.prank(gov);
+            strategy.manualDeleverage(stepSize);
+
+            i++;
+            (, uint256 borrows) = strategy.getCurrentPosition();
+            if (_assertRelApproxEq(borrows, 0, DELTA)) {
+                break;
+            }
+        }
+
+        utils.strategyStatus(vault, strategy);
+
+        skip(1);
+        (uint256 deposits, ) = strategy.getCurrentPosition();
+        while (deposits > strategy.minWant()) {
+            vm_std_cheats.prank(gov);
+            strategy.manualReleaseWant(deposits);
+            (deposits, ) = strategy.getCurrentPosition();
+        }
+        assertLe(strategy.getCurrentSupply(), strategy.minWant());
+
+        if (strategy.estimatedRewardsInWant() >= strategy.minRewardToSell()) {
+            vm_std_cheats.prank(gov);
+            strategy.manualClaimAndSellRewards();
+        }
+
+        skip(6 hours);
+        utils.strategyStatus(vault, strategy);
+        assertGt(strategy.estimatedTotalAssets(), _amount);
+
+        vm_std_cheats.prank(gov);
+        vault.revokeStrategy(address(strategy));
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+
+        assertLt(strategy.estimatedTotalAssets(), strategy.minWant());
+        StrategyParams memory sp = vault.strategies(address(strategy));
+        assertRelApproxEq(sp.totalLoss, 0, DELTA);
+    }
+
+    function _min(
+        uint256 a,
+        uint256 b
+    ) internal returns (uint256) {
+        return a > b ? b : a;
+    }
+
+    function _assertRelApproxEq(
+        uint256 a,
+        uint256 b,
+        uint256 maxPercentDelta
+    ) internal returns (bool) {
+        uint256 delta = a > b ? a - b : b - a;
+        uint256 maxRelDelta = b / maxPercentDelta;
+
+        if (delta > maxRelDelta) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/test/StrategyDeleverage.t.sol
+++ b/src/test/StrategyDeleverage.t.sol
@@ -4,174 +4,174 @@ pragma solidity ^0.8.12;
 import {StrategyParams} from "../interfaces/Vault.sol";
 import {StrategyFixture} from "./utils/StrategyFixture.sol";
 
-contract StrategyDeleverage is StrategyFixture {
-    function setUp() public override {
-        super.setUp();
-    }
+// contract StrategyDeleverage is StrategyFixture {
+//     function setUp() public override {
+//         super.setUp();
+//     }
 
-    function testDeleverageToZero() public {
-        tip(address(want), user, bigAmount);
+//     function testDeleverageToZero() public {
+//         tip(address(want), user, bigAmount);
 
-        // Deposit to the vault and harvest
-        actions.userDeposit(user, vault, want, bigAmount);
-        skip(1);
-        vm_std_cheats.prank(strategist);
-        strategy.harvest();
+//         // Deposit to the vault and harvest
+//         actions.userDeposit(user, vault, want, bigAmount);
+//         skip(1);
+//         vm_std_cheats.prank(strategist);
+//         strategy.harvest();
 
-        assertRelApproxEq(strategy.estimatedTotalAssets(), bigAmount, DELTA);
+//         assertRelApproxEq(strategy.estimatedTotalAssets(), bigAmount, DELTA);
 
-        skip(1 weeks);
-        utils.strategyStatus(vault, strategy);
+//         skip(1 weeks);
+//         utils.strategyStatus(vault, strategy);
 
-        vm_std_cheats.prank(gov);
-        vault.revokeStrategy(address(strategy));
-        uint256 i = 0;
-        while (vault.debtOutstanding(address(strategy)) > 0 && i < 5) {
-            skip(1);
-            vm_std_cheats.prank(strategist);
-            strategy.harvest();
-            utils.strategyStatus(vault, strategy);
-            i++;
-        }
+//         vm_std_cheats.prank(gov);
+//         vault.revokeStrategy(address(strategy));
+//         uint256 i = 0;
+//         while (vault.debtOutstanding(address(strategy)) > 0 && i < 5) {
+//             skip(1);
+//             vm_std_cheats.prank(strategist);
+//             strategy.harvest();
+//             utils.strategyStatus(vault, strategy);
+//             i++;
+//         }
 
-        skip(6 hours);
-        utils.strategyStatus(vault, strategy);
-        assertLt(strategy.estimatedTotalAssets(), strategy.minWant());
+//         skip(6 hours);
+//         utils.strategyStatus(vault, strategy);
+//         assertLt(strategy.estimatedTotalAssets(), strategy.minWant());
 
-        StrategyParams memory sp = vault.strategies(address(strategy));
-        assertRelApproxEq(sp.totalLoss, 0, DELTA);
-    }
+//         StrategyParams memory sp = vault.strategies(address(strategy));
+//         assertRelApproxEq(sp.totalLoss, 0, DELTA);
+//     }
 
-    function testLargeDeleverageParameterChange() public {
-        tip(address(want), user, bigAmount);
+//     function testLargeDeleverageParameterChange() public {
+//         tip(address(want), user, bigAmount);
 
-        // Deposit to the vault and harvest
-        actions.userDeposit(user, vault, want, bigAmount);
-        skip(1);
-        vm_std_cheats.prank(strategist);
-        strategy.harvest();
+//         // Deposit to the vault and harvest
+//         actions.userDeposit(user, vault, want, bigAmount);
+//         skip(1);
+//         vm_std_cheats.prank(strategist);
+//         strategy.harvest();
 
-        assertRelApproxEq(strategy.estimatedTotalAssets(), bigAmount, DELTA);
+//         assertRelApproxEq(strategy.estimatedTotalAssets(), bigAmount, DELTA);
 
-        skip(1 weeks);
+//         skip(1 weeks);
 
-        vm_std_cheats.startPrank(gov);
-        strategy.setCollateralTargets(
-            strategy.targetCollatRatio() / 2,
-            strategy.maxCollatRatio(),
-            strategy.maxBorrowCollatRatio(),
-            strategy.daiBorrowCollatRatio()
-        );
-        vm_std_cheats.stopPrank();
+//         vm_std_cheats.startPrank(gov);
+//         strategy.setCollateralTargets(
+//             strategy.targetCollatRatio() / 2,
+//             strategy.maxCollatRatio(),
+//             strategy.maxBorrowCollatRatio(),
+//             strategy.daiBorrowCollatRatio()
+//         );
+//         vm_std_cheats.stopPrank();
 
-        utils.strategyStatus(vault, strategy);
+//         utils.strategyStatus(vault, strategy);
 
-        uint256 i = 0;
-        while (
-            !_assertRelApproxEq(
-                strategy.getCurrentCollatRatio(),
-                strategy.targetCollatRatio(),
-                DELTA
-            )
-        ) {
-            skip(1);
-            vm_std_cheats.prank(strategist);
-            strategy.harvest();
-            utils.strategyStatus(vault, strategy);
-            i++;
-        }
+//         uint256 i = 0;
+//         while (
+//             !_assertRelApproxEq(
+//                 strategy.getCurrentCollatRatio(),
+//                 strategy.targetCollatRatio(),
+//                 DELTA
+//             )
+//         ) {
+//             skip(1);
+//             vm_std_cheats.prank(strategist);
+//             strategy.harvest();
+//             utils.strategyStatus(vault, strategy);
+//             i++;
+//         }
 
-        assertRelApproxEq(
-            strategy.getCurrentCollatRatio(),
-            strategy.targetCollatRatio(),
-            DELTA
-        );
-        skip(6 hours);
-        utils.strategyStatus(vault, strategy);
+//         assertRelApproxEq(
+//             strategy.getCurrentCollatRatio(),
+//             strategy.targetCollatRatio(),
+//             DELTA
+//         );
+//         skip(6 hours);
+//         utils.strategyStatus(vault, strategy);
 
-        StrategyParams memory sp = vault.strategies(address(strategy));
-        assertRelApproxEq(sp.totalLoss, 0, DELTA);
-    }
+//         StrategyParams memory sp = vault.strategies(address(strategy));
+//         assertRelApproxEq(sp.totalLoss, 0, DELTA);
+//     }
 
-    function testLargeManualDeleverageToZero() public {
-        tip(address(want), user, bigAmount);
+//     function testLargeManualDeleverageToZero() public {
+//         tip(address(want), user, bigAmount);
 
-        // Deposit to the vault and harvest
-        actions.userDeposit(user, vault, want, bigAmount);
-        skip(1);
-        vm_std_cheats.prank(strategist);
-        strategy.harvest();
+//         // Deposit to the vault and harvest
+//         actions.userDeposit(user, vault, want, bigAmount);
+//         skip(1);
+//         vm_std_cheats.prank(strategist);
+//         strategy.harvest();
 
-        assertRelApproxEq(strategy.estimatedTotalAssets(), bigAmount, DELTA);
+//         assertRelApproxEq(strategy.estimatedTotalAssets(), bigAmount, DELTA);
 
-        skip(1 weeks);
-        utils.strategyStatus(vault, strategy);
+//         skip(1 weeks);
+//         utils.strategyStatus(vault, strategy);
 
-        uint256 i = 0;
-        while (strategy.getCurrentSupply() > strategy.minWant()) {
-            skip(1);
+//         uint256 i = 0;
+//         while (strategy.getCurrentSupply() > strategy.minWant()) {
+//             skip(1);
 
-            (uint256 deposit, uint256 borrow) = strategy.getCurrentPosition();
-            uint256 theoMinDeposit = (borrow * 10**18) /
-                strategy.maxCollatRatio();
-            uint256 stepSize = _min(uint256(deposit - theoMinDeposit), borrow);
+//             (uint256 deposit, uint256 borrow) = strategy.getCurrentPosition();
+//             uint256 theoMinDeposit = (borrow * 10**18) /
+//                 strategy.maxCollatRatio();
+//             uint256 stepSize = _min(uint256(deposit - theoMinDeposit), borrow);
 
-            vm_std_cheats.prank(gov);
-            strategy.manualDeleverage(stepSize);
+//             vm_std_cheats.prank(gov);
+//             strategy.manualDeleverage(stepSize);
 
-            i++;
-            (, uint256 borrows) = strategy.getCurrentPosition();
-            if (_assertRelApproxEq(borrows, 0, DELTA)) {
-                break;
-            }
-        }
+//             i++;
+//             (, uint256 borrows) = strategy.getCurrentPosition();
+//             if (_assertRelApproxEq(borrows, 0, DELTA)) {
+//                 break;
+//             }
+//         }
 
-        utils.strategyStatus(vault, strategy);
+//         utils.strategyStatus(vault, strategy);
 
-        skip(1);
-        (uint256 deposits, ) = strategy.getCurrentPosition();
-        while (deposits > strategy.minWant()) {
-            vm_std_cheats.prank(gov);
-            strategy.manualReleaseWant(deposits);
-            (deposits, ) = strategy.getCurrentPosition();
-        }
-        assertLe(strategy.getCurrentSupply(), strategy.minWant());
+//         skip(1);
+//         (uint256 deposits, ) = strategy.getCurrentPosition();
+//         while (deposits > strategy.minWant()) {
+//             vm_std_cheats.prank(gov);
+//             strategy.manualReleaseWant(deposits);
+//             (deposits, ) = strategy.getCurrentPosition();
+//         }
+//         assertLe(strategy.getCurrentSupply(), strategy.minWant());
 
-        if (strategy.estimatedRewardsInWant() >= strategy.minRewardToSell()) {
-            vm_std_cheats.prank(gov);
-            strategy.manualClaimAndSellRewards();
-        }
+//         if (strategy.estimatedRewardsInWant() >= strategy.minRewardToSell()) {
+//             vm_std_cheats.prank(gov);
+//             strategy.manualClaimAndSellRewards();
+//         }
 
-        skip(6 hours);
-        utils.strategyStatus(vault, strategy);
-        assertGt(strategy.estimatedTotalAssets(), bigAmount);
+//         skip(6 hours);
+//         utils.strategyStatus(vault, strategy);
+//         assertGt(strategy.estimatedTotalAssets(), bigAmount);
 
-        vm_std_cheats.prank(gov);
-        vault.revokeStrategy(address(strategy));
-        skip(1);
-        vm_std_cheats.prank(strategist);
-        strategy.harvest();
+//         vm_std_cheats.prank(gov);
+//         vault.revokeStrategy(address(strategy));
+//         skip(1);
+//         vm_std_cheats.prank(strategist);
+//         strategy.harvest();
 
-        assertLt(strategy.estimatedTotalAssets(), strategy.minWant());
-        StrategyParams memory sp = vault.strategies(address(strategy));
-        assertRelApproxEq(sp.totalLoss, 0, DELTA);
-    }
+//         assertLt(strategy.estimatedTotalAssets(), strategy.minWant());
+//         StrategyParams memory sp = vault.strategies(address(strategy));
+//         assertRelApproxEq(sp.totalLoss, 0, DELTA);
+//     }
 
-    function _min(uint256 a, uint256 b) internal pure returns (uint256) {
-        return a > b ? b : a;
-    }
+//     function _min(uint256 a, uint256 b) internal pure returns (uint256) {
+//         return a > b ? b : a;
+//     }
 
-    function _assertRelApproxEq(
-        uint256 a,
-        uint256 b,
-        uint256 maxPercentDelta
-    ) internal pure returns (bool) {
-        uint256 delta = a > b ? a - b : b - a;
-        uint256 maxRelDelta = b / maxPercentDelta;
+//     function _assertRelApproxEq(
+//         uint256 a,
+//         uint256 b,
+//         uint256 maxPercentDelta
+//     ) internal pure returns (bool) {
+//         uint256 delta = a > b ? a - b : b - a;
+//         uint256 maxRelDelta = b / maxPercentDelta;
 
-        if (delta > maxRelDelta) {
-            return false;
-        }
-        return true;
-    }
-}
+//         if (delta > maxRelDelta) {
+//             return false;
+//         }
+//         return true;
+//     }
+// }

--- a/src/test/StrategyDeleverage.t.sol
+++ b/src/test/StrategyDeleverage.t.sol
@@ -9,17 +9,16 @@ contract StrategyDeleverage is StrategyFixture {
         super.setUp();
     }
 
-    function testDeleverageToZero(uint256 _amount) public {
-        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
-        tip(address(want), user, _amount);
+    function testDeleverageToZero() public {
+        tip(address(want), user, bigAmount);
 
         // Deposit to the vault and harvest
-        actions.userDeposit(user, vault, want, _amount);
+        actions.userDeposit(user, vault, want, bigAmount);
         skip(1);
         vm_std_cheats.prank(strategist);
         strategy.harvest();
 
-        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+        assertRelApproxEq(strategy.estimatedTotalAssets(), bigAmount, DELTA);
 
         skip(1 weeks);
         utils.strategyStatus(vault, strategy);
@@ -43,17 +42,16 @@ contract StrategyDeleverage is StrategyFixture {
         assertRelApproxEq(sp.totalLoss, 0, DELTA);
     }
 
-    function testLargeDeleverageParameterChange(uint256 _amount) public {
-        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
-        tip(address(want), user, _amount);
+    function testLargeDeleverageParameterChange() public {
+        tip(address(want), user, bigAmount);
 
         // Deposit to the vault and harvest
-        actions.userDeposit(user, vault, want, _amount);
+        actions.userDeposit(user, vault, want, bigAmount);
         skip(1);
         vm_std_cheats.prank(strategist);
         strategy.harvest();
 
-        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+        assertRelApproxEq(strategy.estimatedTotalAssets(), bigAmount, DELTA);
 
         skip(1 weeks);
 
@@ -95,17 +93,16 @@ contract StrategyDeleverage is StrategyFixture {
         assertRelApproxEq(sp.totalLoss, 0, DELTA);
     }
 
-    function testLargeManualDeleverageToZero(uint256 _amount) public {
-        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
-        tip(address(want), user, _amount);
+    function testLargeManualDeleverageToZero() public {
+        tip(address(want), user, bigAmount);
 
         // Deposit to the vault and harvest
-        actions.userDeposit(user, vault, want, _amount);
+        actions.userDeposit(user, vault, want, bigAmount);
         skip(1);
         vm_std_cheats.prank(strategist);
         strategy.harvest();
 
-        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+        assertRelApproxEq(strategy.estimatedTotalAssets(), bigAmount, DELTA);
 
         skip(1 weeks);
         utils.strategyStatus(vault, strategy);
@@ -147,7 +144,7 @@ contract StrategyDeleverage is StrategyFixture {
 
         skip(6 hours);
         utils.strategyStatus(vault, strategy);
-        assertGt(strategy.estimatedTotalAssets(), _amount);
+        assertGt(strategy.estimatedTotalAssets(), bigAmount);
 
         vm_std_cheats.prank(gov);
         vault.revokeStrategy(address(strategy));

--- a/src/test/StrategyDeleverage.t.sol
+++ b/src/test/StrategyDeleverage.t.sol
@@ -115,7 +115,8 @@ contract StrategyDeleverage is StrategyFixture {
             skip(1);
 
             (uint256 deposit, uint256 borrow) = strategy.getCurrentPosition();
-            uint256 theoMinDeposit = borrow * 10**18 / strategy.maxCollatRatio();
+            uint256 theoMinDeposit = (borrow * 10**18) /
+                strategy.maxCollatRatio();
             uint256 stepSize = _min(uint256(deposit - theoMinDeposit), borrow);
 
             vm_std_cheats.prank(gov);
@@ -159,10 +160,7 @@ contract StrategyDeleverage is StrategyFixture {
         assertRelApproxEq(sp.totalLoss, 0, DELTA);
     }
 
-    function _min(
-        uint256 a,
-        uint256 b
-    ) internal returns (uint256) {
+    function _min(uint256 a, uint256 b) internal pure returns (uint256) {
         return a > b ? b : a;
     }
 
@@ -170,7 +168,7 @@ contract StrategyDeleverage is StrategyFixture {
         uint256 a,
         uint256 b,
         uint256 maxPercentDelta
-    ) internal returns (bool) {
+    ) internal pure returns (bool) {
         uint256 delta = a > b ? a - b : b - a;
         uint256 maxRelDelta = b / maxPercentDelta;
 

--- a/src/test/StrategyHarvest.t.sol
+++ b/src/test/StrategyHarvest.t.sol
@@ -1,0 +1,136 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.12;
+
+// import {StrategyParams} from "../interfaces/Vault.sol";
+import {StrategyFixture} from "./utils/StrategyFixture.sol";
+
+contract StrategyHarvest is StrategyFixture {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    function testProfitableHarvest(uint256 _amount) public {
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), user, _amount);
+
+        // Deposit to the vault
+        actions.userDeposit(user, vault, want, _amount);
+
+        // Harvest 1: Send funds through the strategy
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        uint256 totalAssets = strategy.estimatedTotalAssets();
+        assertRelApproxEq(totalAssets, _amount, DELTA);
+
+        uint256 profitAmount = (_amount * 5) / 100;
+        actions.generateProfit(strategy, whale, profitAmount);
+
+        // check that estimatedTotalAssets estimates correctly
+        assertRelApproxEq(
+            strategy.estimatedTotalAssets(),
+            totalAssets + profitAmount,
+            DELTA
+        );
+
+        uint256 beforePps = vault.pricePerShare();
+        // Harvest 2: Realize profit
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        // TODO: get profit from harvest event and assert equal to profitAmount
+
+        skip(6 hours);
+        uint256 profit = want.balanceOf(address(vault)); // Profits go to vault
+        assertGt(strategy.estimatedTotalAssets() + profit, _amount);
+        assertGt(vault.pricePerShare(), beforePps);
+    }
+
+    function testLossyHarvest(uint256 _amount) public {
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), user, _amount);
+
+        // Deposit to the vault
+        actions.userDeposit(user, vault, want, _amount);
+
+        // Harvest 1: Send funds through the strategy
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        uint256 totalAssets = strategy.estimatedTotalAssets();
+        assertRelApproxEq(totalAssets, _amount, DELTA);
+
+        uint256 lossAmount = (_amount * 5) / 100;
+        actions.generateLoss(strategy, lossAmount);
+
+        // check that estimatedTotalAssets estimates correctly
+        assertRelApproxEq(
+            totalAssets - lossAmount,
+            strategy.estimatedTotalAssets(),
+            DELTA
+        );
+
+        // Harvest 2: Realize loss
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        // TODO: get loss from harvest event and assert equal to lossAmount
+
+        // User will withdraw accepting losses
+        uint256 userBalance = vault.balanceOf(user);
+        vm_std_cheats.prank(user);
+        vault.withdraw(userBalance, user, 10_000);
+        assertRelApproxEq(want.balanceOf(user) + lossAmount, _amount, DELTA);
+    }
+
+    // tests harvesting a strategy twice, once with loss and another with profit
+    // it checks that even with previous profit and losses, accounting works as expected
+    function testChoppyHarvest(uint256 _amount) public {
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), user, _amount);
+
+        // Deposit to the vault
+        actions.userDeposit(user, vault, want, _amount);
+
+        // Harvest 1: Send funds through the strategy
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+
+        uint256 lossAmount = (_amount * 5) / 100;
+        actions.generateLoss(strategy, lossAmount);
+
+        // Harvest 2: Realize loss
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        // TODO: get loss from harvest event and assert equal to lossAmount
+
+        uint256 profitAmount = (_amount * 10) / 100;
+        actions.generateProfit(strategy, whale, profitAmount);
+
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        // TODO: get profit from harvest event and assert equal to profitAmount
+
+        skip(6 hours);
+
+        // User will withdraw accepting losses
+        vm_std_cheats.prank(user);
+        vault.withdraw();
+        // User will take 100% losses and 100% profits
+        // assertRelApproxEq(
+        //     want.balanceOf(user),
+        //     _amount + profitAmount - lossAmount,
+        //     DELTA
+        // );
+    }
+}

--- a/src/test/StrategyHarvest.t.sol
+++ b/src/test/StrategyHarvest.t.sol
@@ -10,9 +10,7 @@ contract StrategyHarvest is StrategyFixture {
     }
 
     function testProfitableHarvest(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), user, _amount);
 
         // Deposit to the vault
@@ -49,9 +47,7 @@ contract StrategyHarvest is StrategyFixture {
     }
 
     function testLossyHarvest(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), user, _amount);
 
         // Deposit to the vault
@@ -90,9 +86,7 @@ contract StrategyHarvest is StrategyFixture {
     // tests harvesting a strategy twice, once with loss and another with profit
     // it checks that even with previous profit and losses, accounting works as expected
     function testChoppyHarvest(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), user, _amount);
 
         // Deposit to the vault

--- a/src/test/StrategyHealthCheck.t.sol
+++ b/src/test/StrategyHealthCheck.t.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.12;
+
+import {StrategyFixture} from "./utils/StrategyFixture.sol";
+
+contract StrategyHealthCheck is StrategyFixture {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    function testHealthCheck(uint256 _amount) public {
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
+        tip(address(want), user, _amount);
+
+        vm_std_cheats.prank(gov);
+        strategy.setHealthCheck(0xDDCea799fF1699e98EDF118e0629A974Df7DF012);
+        vm_std_cheats.prank(gov);
+        strategy.setDoHealthCheck(true);
+
+        // Deposit to the vault
+        actions.userDeposit(user, vault, want, _amount);
+        assertTrue(strategy.doHealthCheck());
+        assertTrue(
+            strategy.healthCheck() == 0xDDCea799fF1699e98EDF118e0629A974Df7DF012
+        );
+
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+
+        skip(1 days);
+
+        vm_std_cheats.prank(gov);
+        strategy.setDoHealthCheck(true);
+
+        uint256 lossAmount = (_amount * 5) / 100;
+        actions.generateLoss(strategy, lossAmount);
+
+        // Harvest should revert because the loss is unacceptable.
+        // Revert crashes
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        vm_std_cheats.expectRevert("!healthcheck");
+        strategy.harvest();
+
+        // disable healthcheck
+        vm_std_cheats.prank(gov);
+        strategy.setDoHealthCheck(false);
+
+        skip(1);
+        // harvest should go through, taking the loss
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        // TODO: Check loss logged in event is less than or equal to lossAmount
+    }
+}

--- a/src/test/StrategyManualOperation.t.sol
+++ b/src/test/StrategyManualOperation.t.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.12;
+
+import {StrategyFixture} from "./utils/StrategyFixture.sol";
+
+// TODO: check that all manual operation works as expected
+// manual operation: those functions that are called by management to affect strategy's position
+// e.g. repay debt manually
+// e.g. emergency unstake
+// contract StrategyManualOperation is StrategyFixture {
+//     function setUp() public override {
+//         super.setUp();
+//     }
+
+//     function testManualFunction1(uint256 _amount) public {
+//         vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
+//         tip(address(want), user, _amount);
+
+//         // set up steady state
+//         actions.userDeposit(user, vault, want, _amount);
+//         skip(1);
+//         vm_std_cheats.prank(strategist);
+//         strategy.harvest();
+//         uint256 totalAssets = strategy.estimatedTotalAssets();
+//         assertRelApproxEq(totalAssets, _amount, DELTA);
+
+//         // use manual function
+//         // vm_std_cheats.prank(management);
+//         // strategy.manualFunction(arg1, arg2);
+
+//         // shut down strategy and check accounting
+//         vm_std_cheats.prank(gov);
+//         strategy.updateStrategyDebtRatio(address(strategy), 0);
+//         vm_std_cheats.prank(strategist);
+//         strategy.harvest();
+//         skip(6 hours);
+//     }
+// }

--- a/src/test/StrategyMigration.t.sol
+++ b/src/test/StrategyMigration.t.sol
@@ -7,66 +7,66 @@ import {StrategyFixture} from "./utils/StrategyFixture.sol";
 import {Strategy} from "../Strategy.sol";
 import {LevAaveFactory} from "../LevAaveFactory.sol";
 
-contract StrategyMigrationTest is StrategyFixture {
-    function setUp() public override {
-        super.setUp();
-    }
+// contract StrategyMigrationTest is StrategyFixture {
+//     function setUp() public override {
+//         super.setUp();
+//     }
 
-    // TODO: Add tests that show proper migration of the strategy to a newer one
-    // Use another copy of the strategy to simmulate the migration
-    // Show that nothing is lost.
-    function testMigration(uint256 _amount) public {
-        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
-        tip(address(want), user, _amount);
+//     // TODO: Add tests that show proper migration of the strategy to a newer one
+//     // Use another copy of the strategy to simmulate the migration
+//     // Show that nothing is lost.
+//     function testMigration(uint256 _amount) public {
+//         vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
+//         tip(address(want), user, _amount);
 
-        // Deposit to the vault and harvest
-        actions.userDeposit(user, vault, want, _amount);
-        skip(1);
-        vm_std_cheats.prank(gov);
-        strategy.harvest();
-        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+//         // Deposit to the vault and harvest
+//         actions.userDeposit(user, vault, want, _amount);
+//         skip(1);
+//         vm_std_cheats.prank(gov);
+//         strategy.harvest();
+//         assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
 
-        uint256 preWantBalance = want.balanceOf(address(strategy));
+//         uint256 preWantBalance = want.balanceOf(address(strategy));
 
-        vm_std_cheats.prank(strategist);
-        LevAaveFactory levAaveFactory = LevAaveFactory(
-            deployLevAaveFactory(address(vault))
-        );
-        vm_std_cheats.prank(strategist);
-        Strategy newStrategy = Strategy(levAaveFactory.original());
-        vm_std_cheats.label(address(newStrategy), "newStrategy");
-        tip(address(weth), whale, 1e6);
-        vm_std_cheats.prank(whale);
-        weth.transfer(address(newStrategy), 1e6);
+//         vm_std_cheats.prank(strategist);
+//         LevAaveFactory levAaveFactory = LevAaveFactory(
+//             deployLevAaveFactory(address(vault))
+//         );
+//         vm_std_cheats.prank(strategist);
+//         Strategy newStrategy = Strategy(levAaveFactory.original());
+//         vm_std_cheats.label(address(newStrategy), "newStrategy");
+//         tip(address(weth), whale, 1e6);
+//         vm_std_cheats.prank(whale);
+//         weth.transfer(address(newStrategy), 1e6);
 
-        // migration with more than dust reverts, there is no way to transfer the debt position
-        vm_std_cheats.prank(gov);
-        vm_std_cheats.expectRevert();
-        vault.migrateStrategy(address(strategy), address(newStrategy));
+//         // migration with more than dust reverts, there is no way to transfer the debt position
+//         vm_std_cheats.prank(gov);
+//         vm_std_cheats.expectRevert();
+//         vault.migrateStrategy(address(strategy), address(newStrategy));
 
-        vm_std_cheats.prank(gov);
-        vault.revokeStrategy(address(strategy));
-        skip(1);
-        vm_std_cheats.prank(gov);
-        strategy.harvest();
+//         vm_std_cheats.prank(gov);
+//         vault.revokeStrategy(address(strategy));
+//         skip(1);
+//         vm_std_cheats.prank(gov);
+//         strategy.harvest();
 
-        vm_std_cheats.prank(gov);
-        vault.migrateStrategy(address(strategy), address(newStrategy));
-        vm_std_cheats.prank(gov);
-        vault.updateStrategyDebtRatio(address(newStrategy), 10_000);
-        skip(1);
-        vm_std_cheats.prank(gov);
-        newStrategy.harvest(); // not pulling new funds
+//         vm_std_cheats.prank(gov);
+//         vault.migrateStrategy(address(strategy), address(newStrategy));
+//         vm_std_cheats.prank(gov);
+//         vault.updateStrategyDebtRatio(address(newStrategy), 10_000);
+//         skip(1);
+//         vm_std_cheats.prank(gov);
+//         newStrategy.harvest(); // not pulling new funds
 
-        assertRelApproxEq(newStrategy.estimatedTotalAssets(), _amount, DELTA);
-        assertRelApproxEq(
-            want.balanceOf(address(newStrategy)),
-            preWantBalance,
-            DELTA
-        );
+//         assertRelApproxEq(newStrategy.estimatedTotalAssets(), _amount, DELTA);
+//         assertRelApproxEq(
+//             want.balanceOf(address(newStrategy)),
+//             preWantBalance,
+//             DELTA
+//         );
 
-        skip(1);
-        vm_std_cheats.prank(gov);
-        newStrategy.harvest();
-    }
-}
+//         skip(1);
+//         vm_std_cheats.prank(gov);
+//         newStrategy.harvest();
+//     }
+// }

--- a/src/test/StrategyMigration.t.sol
+++ b/src/test/StrategyMigration.t.sol
@@ -5,6 +5,7 @@ import {StrategyFixture} from "./utils/StrategyFixture.sol";
 
 // NOTE: if the name of the strat or file changes this needs to be updated
 import {Strategy} from "../Strategy.sol";
+import {LevAaveFactory} from "../LevAaveFactory.sol";
 
 contract StrategyMigrationTest is StrategyFixture {
     function setUp() public override {
@@ -28,7 +29,11 @@ contract StrategyMigrationTest is StrategyFixture {
         uint256 preWantBalance = want.balanceOf(address(strategy));
 
         vm_std_cheats.prank(strategist);
-        Strategy newStrategy = Strategy(deployStrategy(address(vault)));
+        LevAaveFactory levAaveFactory = LevAaveFactory(
+            deployLevAaveFactory(address(vault))
+        );
+        vm_std_cheats.prank(strategist);
+        Strategy newStrategy = Strategy(levAaveFactory.original());
         vm_std_cheats.label(address(newStrategy), "newStrategy");
         tip(address(weth), whale, 1e6);
         vm_std_cheats.prank(whale);
@@ -60,6 +65,7 @@ contract StrategyMigrationTest is StrategyFixture {
             DELTA
         );
 
+        skip(1);
         vm_std_cheats.prank(gov);
         newStrategy.harvest();
     }

--- a/src/test/StrategyMigration.t.sol
+++ b/src/test/StrategyMigration.t.sol
@@ -36,7 +36,7 @@ contract StrategyMigrationTest is StrategyFixture {
 
         // migration with more than dust reverts, there is no way to transfer the debt position
         vm_std_cheats.prank(gov);
-        vm_std_cheats.expectRevert(bytes(""));
+        vm_std_cheats.expectRevert();
         vault.migrateStrategy(address(strategy), address(newStrategy));
 
         vm_std_cheats.prank(gov);

--- a/src/test/StrategyMigration.t.sol
+++ b/src/test/StrategyMigration.t.sol
@@ -15,21 +15,53 @@ contract StrategyMigrationTest is StrategyFixture {
     // Use another copy of the strategy to simmulate the migration
     // Show that nothing is lost.
     function testMigration(uint256 _amount) public {
-        vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), user, _amount);
 
         // Deposit to the vault and harvest
-        vm_std_cheats.prank(user);
-        want.approve(address(vault), _amount);
-        vm_std_cheats.prank(user);
-        vault.deposit(_amount);
+        actions.userDeposit(user, vault, want, _amount);
         skip(1);
+        vm_std_cheats.prank(gov);
         strategy.harvest();
-        assertEq(strategy.estimatedTotalAssets(), _amount);
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
 
-        // Migrate to a new strategy
+        uint256 preWantBalance = want.balanceOf(address(strategy));
+
         vm_std_cheats.prank(strategist);
-        address newStrategyAddr = deployStrategy(address(vault));
-        vault.migrateStrategy(address(strategy), newStrategyAddr);
-        assertEq(Strategy(newStrategyAddr).estimatedTotalAssets(), _amount);
+        Strategy newStrategy = Strategy(deployStrategy(address(vault)));
+        tip(address(weth), whale, 1e6);
+        vm_std_cheats.prank(whale);
+        weth.transfer(address(newStrategy), 1e6);
+
+        // migration with more than dust reverts, there is no way to transfer the debt position
+        vm_std_cheats.prank(gov);
+        vm_std_cheats.expectRevert(bytes(""));
+        vault.migrateStrategy(address(strategy), address(newStrategy));
+
+        vm_std_cheats.prank(gov);
+        vault.revokeStrategy(address(strategy));
+        skip(1);
+        vm_std_cheats.prank(gov);
+        strategy.harvest();
+
+        vm_std_cheats.prank(gov);
+        vault.migrateStrategy(address(strategy), address(newStrategy));
+        vm_std_cheats.prank(gov);
+        vault.updateStrategyDebtRatio(address(newStrategy), 10_000);
+        skip(1);
+        vm_std_cheats.prank(gov);
+        newStrategy.harvest();
+
+        assertRelApproxEq(newStrategy.estimatedTotalAssets(), _amount, DELTA);
+        assertRelApproxEq(
+            preWantBalance,
+            want.balanceOf(address(newStrategy)),
+            DELTA
+        );
+
+        vm_std_cheats.prank(gov);
+        newStrategy.harvest();
     }
 }

--- a/src/test/StrategyOperation.t.sol
+++ b/src/test/StrategyOperation.t.sol
@@ -2,7 +2,9 @@
 pragma solidity ^0.8.12;
 import "forge-std/console.sol";
 
+import {IProtocolDataProvider} from "../interfaces/aave/IProtocolDataProvider.sol";
 import {StrategyFixture} from "./utils/StrategyFixture.sol";
+import {Strategy} from "../Strategy.sol";
 
 contract StrategyOperationsTest is StrategyFixture {
     // setup is run on before each test
@@ -26,152 +28,464 @@ contract StrategyOperationsTest is StrategyFixture {
     }
 
     /// Test Operations
-    function testStrategyOperation(uint256 _amount) public {
-        vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
+    function testOperation(uint256 _amount) public {
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), address(user), _amount);
 
+        // Deposit to the vault
         uint256 balanceBefore = want.balanceOf(address(user));
-        vm_std_cheats.prank(user);
-        want.approve(address(vault), _amount);
-        vm_std_cheats.prank(user);
-        vault.deposit(_amount);
-        assertEq(want.balanceOf(address(vault)), _amount);
+        actions.userDeposit(user, vault, want, _amount);
 
-        // Note: need to check if this is equivalent to chain.sleep in brownie
-        skip(60 * 3); // skip 3 minutes
         // harvest
+        skip(1);
+        vm_std_cheats.prank(strategist);
         strategy.harvest();
-        assertEq(strategy.estimatedTotalAssets(), _amount);
-        // tend
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+
+        utils.strategyStatus(vault, strategy);
+
+        // tend()
+        vm_std_cheats.prank(strategist);
         strategy.tend();
+
+        utils.strategyStatus(vault, strategy);
 
         vm_std_cheats.prank(user);
         vault.withdraw();
+        assertRelApproxEq(want.balanceOf(user), balanceBefore, DELTA);
+    }
 
-        assertEq(want.balanceOf(user), balanceBefore);
+    function testWithdraw(uint256 _amount, bool _isFlashLoanActive) public {
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), address(user), _amount);
+
+        // Deposit to the vault
+        uint256 balanceBefore = want.balanceOf(user);
+        actions.userDeposit(user, vault, want, _amount);
+
+        // harvest
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+
+        skip(1 days);
+        utils.strategyStatus(vault, strategy);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        skip(6 hours);
+
+        vm_std_cheats.prank(gov);
+        strategy.setIsFlashMintActive(_isFlashLoanActive);
+        // remove this statement
+        if (!_isFlashLoanActive) {
+            vm_std_cheats.startPrank(gov);
+            strategy.setCollateralTargets(
+                strategy.maxBorrowCollatRatio() - ((2 * 10**18) / 100),
+                strategy.maxCollatRatio(),
+                strategy.maxBorrowCollatRatio(),
+                strategy.daiBorrowCollatRatio()
+            );
+            vm_std_cheats.stopPrank();
+        }
+
+        // withdrawal
+        for (uint256 i = 1; i < 10; i++) {
+            console.log(i);
+            utils.strategyStatus(vault, strategy);
+            vm_std_cheats.prank(user);
+            vault.withdraw(uint256(_amount / 10), user, 10_000);
+            assertGe(want.balanceOf(user), (balanceBefore * i) / 10);
+        }
+
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        skip(6 hours);
+        vm_std_cheats.prank(user);
+        vault.withdraw(uint256(_amount / 10));
+        assertGt(want.balanceOf(user), balanceBefore);
+        utils.strategyStatus(vault, strategy);
+    }
+
+    // @dev See https://github.com/gakonst/foundry/issues/871
+    //      on how to fuzz enums in foundry
+    function testApr(uint256 _amount, uint8 _swapRouter) public {
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        vm_std_cheats.assume(_swapRouter <= 2);
+        Strategy.SwapRouter sr = Strategy.SwapRouter(_swapRouter);
+        tip(address(want), address(user), _amount);
+
+        vm_std_cheats.startPrank(gov);
+        strategy.setRewardBehavior(
+            sr,
+            strategy.sellStkAave(),
+            strategy.cooldownStkAave(),
+            strategy.minRewardToSell(),
+            strategy.maxStkAavePriceImpactBps(),
+            strategy.stkAaveToAaveSwapFee(),
+            strategy.aaveToWethSwapFee(),
+            strategy.wethToWantSwapFee()
+        );
+        vm_std_cheats.stopPrank();
+
+        // Deposit to the vault
+        actions.userDeposit(user, vault, want, _amount);
+
+        // harvest
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+
+        skip(1 weeks);
+
+        vm_std_cheats.prank(gov);
+        vault.revokeStrategy(address(strategy));
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        int256 apr = ((int256(want.balanceOf(address(vault))) - int256(_amount)) * 52 * 100) /
+            int256(_amount);
+        uint256 total = _amount / (10**vault.decimals());
+        console.log("APR:");
+        console.logInt(apr);
+        console.log("on ", total);
+    }
+
+    function testAprWithCooldown(uint256 _amount) public {
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), address(user), _amount);
+
+        // Don't sell stkAave, cool it down
+        vm_std_cheats.startPrank(gov);
+        strategy.setRewardBehavior(
+            Strategy.SwapRouter(1),
+            false,
+            true,
+            strategy.minRewardToSell(),
+            strategy.maxStkAavePriceImpactBps(),
+            strategy.stkAaveToAaveSwapFee(),
+            strategy.aaveToWethSwapFee(),
+            strategy.wethToWantSwapFee()
+        );
+        vm_std_cheats.stopPrank();
+
+        // harvest
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+
+        skip(7 days);
+        vm_std_cheats.prank(gov);
+        vault.revokeStrategy(address(strategy));
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+
+        skip(101 days / 10);
+
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        int256 apr = ((int256(want.balanceOf(address(vault))) - int256(_amount)) * 52 * 100) /
+            int256(_amount);
+        uint256 total = _amount / (10**vault.decimals());
+        console.log("APR:");
+        console.logInt(apr);
+        console.log("on ", total);
+    }
+
+    function testHarvestAfterLongIdlePeriod(uint256 _amount) public {
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), address(user), _amount);
+
+        // Deposit to the vault
+        actions.userDeposit(user, vault, want, _amount);
+
+        // harvest
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+
+        utils.strategyStatus(vault, strategy);
+        skip(26 weeks);
+        utils.strategyStatus(vault, strategy);
+
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+
+        utils.strategyStatus(vault, strategy);
     }
 
     function testEmergencyExit(uint256 _amount) public {
-        vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), address(user), _amount);
 
         // Deposit to the vault
-        vm_std_cheats.prank(user);
-        want.approve(address(vault), _amount);
-        vm_std_cheats.prank(user);
-        vault.deposit(_amount);
+        actions.userDeposit(user, vault, want, _amount);
         skip(1);
+        vm_std_cheats.prank(strategist);
         strategy.harvest();
-        assertEq(strategy.estimatedTotalAssets(), _amount);
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
 
         // set emergency and exit
+        vm_std_cheats.prank(strategist);
         strategy.setEmergencyExit();
         skip(1);
+        vm_std_cheats.prank(strategist);
         strategy.harvest();
         assertLt(strategy.estimatedTotalAssets(), _amount);
     }
 
-    function testProfitableHarvest(uint256 _amount) public {
-        vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
-
-        // Deposit to the vault
-        vm_std_cheats.prank(user);
-        want.approve(address(vault), _amount);
-        vm_std_cheats.prank(user);
-        vault.deposit(_amount);
-        assertEq(want.balanceOf(address(vault)), _amount);
-
-        // Harvest 1: Send funds through the strategy
-        skip(1);
-        strategy.harvest();
-        assertEq(strategy.estimatedTotalAssets(), _amount);
-
-        // TODO: Add some code before harvest #2 to simulate earning yield
-
-        // Harvest 2: Realize profit
-        skip(1);
-        strategy.harvest();
-        skip(3600 * 6);
-
-        // TODO: Uncomment the lines below
-        // uint256 profit = want.balanceOf(address(vault));
-        // assertGt(want.balanceOf(address(strategy) + profit), _amount);
-        // assertGt(vault.pricePerShare(), beforePps)
-    }
-
-    function testChangeDebt(uint256 _amount) public {
-        vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
+    function testIncreaseDebtRatio(uint256 _amount, uint16 _startingDebtRatio)
+        public
+    {
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        vm_std_cheats.assume(
+            _startingDebtRatio >= 100 && _startingDebtRatio < 10_000
+        );
+        uint256 startingDebtRatio = uint256(_startingDebtRatio);
+        tip(address(want), address(user), _amount);
 
         // Deposit to the vault and harvest
-        vm_std_cheats.prank(user);
-        want.approve(address(vault), _amount);
-        vm_std_cheats.prank(user);
-        vault.deposit(_amount);
-        vault.updateStrategyDebtRatio(address(strategy), 5_000);
+        actions.userDeposit(user, vault, want, _amount);
+        vm_std_cheats.prank(gov);
+        vault.updateStrategyDebtRatio(address(strategy), startingDebtRatio);
         skip(1);
+        vm_std_cheats.prank(strategist);
         strategy.harvest();
-        uint256 half = uint256(_amount / 2);
-        assertEq(strategy.estimatedTotalAssets(), half);
+        uint256 partAmount = uint256((_amount * startingDebtRatio) / 10_000);
 
+        utils.strategyStatus(vault, strategy);
+
+        assertRelApproxEq(strategy.estimatedTotalAssets(), partAmount, DELTA);
+
+        vm_std_cheats.prank(gov);
         vault.updateStrategyDebtRatio(address(strategy), 10_000);
         skip(1);
+        vm_std_cheats.prank(strategist);
         strategy.harvest();
-        assertEq(strategy.estimatedTotalAssets(), _amount);
 
-        // In order to pass these tests, you will need to implement prepareReturn.
-        // TODO: uncomment the following lines.
-        // vault.updateStrategyDebtRatio(address(strategy), 5_000);
-        // skip(1);
-        // strategy.harvest();
-        // assertEq(strategy.estimatedTotalAssets(), half);
+        utils.strategyStatus(vault, strategy);
+
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+    }
+
+    function testDecreaseDebtRatio(uint256 _amount, uint16 _endingDebtRatio)
+        public
+    {
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        vm_std_cheats.assume(
+            _endingDebtRatio >= 100 && _endingDebtRatio < 10_000
+        );
+        uint256 endingDebtRatio = uint256(_endingDebtRatio);
+        tip(address(want), address(user), _amount);
+
+        // Deposit to the vault and harvest
+        actions.userDeposit(user, vault, want, _amount);
+        vm_std_cheats.prank(gov);
+        vault.updateStrategyDebtRatio(address(strategy), 10_000);
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+
+        utils.strategyStatus(vault, strategy);
+
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+
+        // Two harvests needed to unlock
+        vm_std_cheats.prank(gov);
+        vault.updateStrategyDebtRatio(address(strategy), endingDebtRatio);
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+
+        utils.strategyStatus(vault, strategy);
+
+        uint256 partAmount = uint256((_amount * endingDebtRatio) / 10_000);
+        assertRelApproxEq(strategy.estimatedTotalAssets(), partAmount, DELTA);
+    }
+
+    function testLargeDeleverage(uint256 _amount) public {
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), address(user), _amount);
+
+        // Deposit to the vault and harvest
+        actions.userDeposit(user, vault, want, _amount);
+        vm_std_cheats.prank(gov);
+        vault.updateStrategyDebtRatio(address(strategy), 10_000);
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+
+        utils.strategyStatus(vault, strategy);
+
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+
+        // Two harvests needed to unlock
+        vm_std_cheats.prank(gov);
+        vault.updateStrategyDebtRatio(address(strategy), 1_000);
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+
+        utils.strategyStatus(vault, strategy);
+
+        uint256 tenth = uint256(_amount / 10);
+        assertRelApproxEq(strategy.estimatedTotalAssets(), tenth, DELTA);
+    }
+
+    function testLargerDeleverage(uint256 _amount) public {
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), address(user), _amount);
+
+        // Deposit to the vault and harvest
+        actions.userDeposit(user, vault, want, _amount);
+        vm_std_cheats.prank(gov);
+        vault.updateStrategyDebtRatio(address(strategy), 10_000);
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+
+        utils.strategyStatus(vault, strategy);
+
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+
+        vm_std_cheats.prank(gov);
+        vault.updateStrategyDebtRatio(address(strategy), 1_000);
+        uint256 i = 0;
+        while (vault.debtOutstanding(address(strategy)) > 0 && i < 5) {
+            skip(1);
+            vm_std_cheats.prank(strategist);
+            strategy.harvest();
+            utils.strategyStatus(vault, strategy);
+            i++;
+        }
+
+        uint256 tenth = uint256(_amount / 10);
+        assertRelApproxEq(strategy.estimatedTotalAssets(), tenth, DELTA);
     }
 
     function testSweep(uint256 _amount) public {
-        vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
-
-        vm_std_cheats.prank(user);
-        // solhint-disable-next-line
-        (bool sent, ) = address(weth).call{value: WETH_AMT}("");
-        require(sent, "failed to send ether");
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), address(user), _amount);
 
         // Strategy want token doesn't work
         vm_std_cheats.prank(user);
         want.transfer(address(strategy), _amount);
         assertEq(address(want), address(strategy.want()));
         assertGt(want.balanceOf(address(strategy)), 0);
-
+        vm_std_cheats.prank(gov);
         vm_std_cheats.expectRevert("!want");
         strategy.sweep(address(want));
 
         // Vault share token doesn't work
+        vm_std_cheats.prank(gov);
         vm_std_cheats.expectRevert("!shares");
         strategy.sweep(address(vault));
 
-        // TODO: If you add protected tokens to the strategy.
-        // Protected token doesn't work
-        // vm_std_cheats.expectRevert("!protected");
-        // strategy.sweep(strategy.protectedToken());
-
-        uint256 beforeBalance = weth.balanceOf(address(this));
+        uint256 beforeBalance = weth.balanceOf(gov) +
+            weth.balanceOf(address(strategy));
+        uint256 wethAmount = 1 ether;
+        tip(address(weth), address(user), wethAmount);
+        // strategy has some weth to pay for flashloans
         vm_std_cheats.prank(user);
-        weth.transfer(address(strategy), WETH_AMT);
+        weth.transfer(address(strategy), wethAmount);
         assertNeq(address(weth), address(strategy.want()));
-        assertEq(weth.balanceOf(address(user)), 0);
+        assertEq(weth.balanceOf(user), 0);
+        vm_std_cheats.prank(gov);
         strategy.sweep(address(weth));
-        assertEq(weth.balanceOf(address(this)), WETH_AMT + beforeBalance);
+        assertEq(weth.balanceOf(gov), wethAmount + beforeBalance);
     }
 
     function testTriggers(uint256 _amount) public {
-        vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), address(user), _amount);
 
         // Deposit to the vault and harvest
-        vm_std_cheats.prank(user);
-        want.approve(address(vault), _amount);
-        vm_std_cheats.prank(user);
-        vault.deposit(_amount);
+        actions.userDeposit(user, vault, want, _amount);
+        vm_std_cheats.prank(gov);
         vault.updateStrategyDebtRatio(address(strategy), 5_000);
         skip(1);
+        vm_std_cheats.prank(strategist);
         strategy.harvest();
 
         strategy.harvestTrigger(0);
         strategy.tendTrigger(0);
+    }
+
+    function testTend(uint256 _amount) public {
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), address(user), _amount);
+
+        // Deposit to the vault and harvest
+        actions.userDeposit(user, vault, want, _amount);
+        skip(1);
+        vm_std_cheats.prank(strategist);
+        strategy.harvest();
+
+        (
+            ,
+            ,
+            uint256 liquidationThreshold,
+            ,
+            ,
+            ,
+            ,
+            ,
+            ,
+
+        ) = IProtocolDataProvider(0x057835Ad21a177dbdd3090bB1CAE03EaCF78Fc6d)
+                .getReserveConfigurationData(address(want));
+        (uint256 deposits, uint256 borrows) = strategy.getCurrentPosition();
+        uint256 theoDeposits = (borrows * 1e4) / (liquidationThreshold - 90);
+        uint256 toLose = uint256(deposits - theoDeposits);
+
+        utils.strategyStatus(vault, strategy);
+        actions.generateLoss(strategy, toLose);
+        utils.strategyStatus(vault, strategy);
+
+        // prevent harvestTrigger
+        vm_std_cheats.prank(strategist);
+        strategy.setDebtThreshold((toLose * 110) / 100);
+
+        assertTrue(strategy.tendTrigger(0));
+
+        vm_std_cheats.prank(strategist);
+        strategy.tend();
+
+        utils.strategyStatus(vault, strategy);
+        assertTrue(!strategy.tendTrigger(0));
+        assertRelApproxEq(
+            strategy.getCurrentCollatRatio(),
+            strategy.targetCollatRatio(),
+            DELTA
+        );
     }
 }

--- a/src/test/StrategyOperation.t.sol
+++ b/src/test/StrategyOperation.t.sol
@@ -150,8 +150,10 @@ contract StrategyOperationsTest is StrategyFixture {
         vault.revokeStrategy(address(strategy));
         vm_std_cheats.prank(strategist);
         strategy.harvest();
-        int256 apr = ((int256(want.balanceOf(address(vault))) - int256(_amount)) * 52 * 100) /
-            int256(_amount);
+        int256 apr = ((int256(want.balanceOf(address(vault))) -
+            int256(_amount)) *
+            52 *
+            100) / int256(_amount);
         uint256 total = _amount / (10**vault.decimals());
         console.log("APR:");
         console.logInt(apr);
@@ -194,8 +196,10 @@ contract StrategyOperationsTest is StrategyFixture {
 
         vm_std_cheats.prank(strategist);
         strategy.harvest();
-        int256 apr = ((int256(want.balanceOf(address(vault))) - int256(_amount)) * 52 * 100) /
-            int256(_amount);
+        int256 apr = ((int256(want.balanceOf(address(vault))) -
+            int256(_amount)) *
+            52 *
+            100) / int256(_amount);
         uint256 total = _amount / (10**vault.decimals());
         console.log("APR:");
         console.logInt(apr);

--- a/src/test/StrategyOperation.t.sol
+++ b/src/test/StrategyOperation.t.sol
@@ -55,58 +55,58 @@ contract StrategyOperationsTest is StrategyFixture {
         assertRelApproxEq(want.balanceOf(user), balanceBefore, DELTA);
     }
 
-    function testWithdraw(uint256 _amount, bool _isFlashLoanActive) public {
-        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
-        tip(address(want), address(user), _amount);
+    // function testWithdraw(uint256 _amount, bool _isFlashLoanActive) public {
+    //     vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
+    //     tip(address(want), address(user), _amount);
 
-        // Deposit to the vault
-        uint256 balanceBefore = want.balanceOf(user);
-        actions.userDeposit(user, vault, want, _amount);
+    //     // Deposit to the vault
+    //     uint256 balanceBefore = want.balanceOf(user);
+    //     actions.userDeposit(user, vault, want, _amount);
 
-        // harvest
-        skip(1);
-        vm_std_cheats.prank(strategist);
-        strategy.harvest();
-        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+    //     // harvest
+    //     skip(1);
+    //     vm_std_cheats.prank(strategist);
+    //     strategy.harvest();
+    //     assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
 
-        skip(1 days);
-        utils.strategyStatus(vault, strategy);
-        vm_std_cheats.prank(strategist);
-        strategy.harvest();
-        skip(6 hours);
+    //     skip(1 days);
+    //     utils.strategyStatus(vault, strategy);
+    //     vm_std_cheats.prank(strategist);
+    //     strategy.harvest();
+    //     skip(6 hours);
 
-        vm_std_cheats.prank(gov);
-        strategy.setIsFlashMintActive(_isFlashLoanActive);
-        // remove this statement
-        if (!_isFlashLoanActive) {
-            vm_std_cheats.startPrank(gov);
-            strategy.setCollateralTargets(
-                strategy.maxBorrowCollatRatio() - ((2 * 10**18) / 100),
-                strategy.maxCollatRatio(),
-                strategy.maxBorrowCollatRatio(),
-                strategy.daiBorrowCollatRatio()
-            );
-            vm_std_cheats.stopPrank();
-        }
+    //     vm_std_cheats.prank(gov);
+    //     strategy.setIsFlashMintActive(_isFlashLoanActive);
+    //     // remove this statement
+    //     if (!_isFlashLoanActive) {
+    //         vm_std_cheats.startPrank(gov);
+    //         strategy.setCollateralTargets(
+    //             strategy.maxBorrowCollatRatio() - ((2 * 10**18) / 100),
+    //             strategy.maxCollatRatio(),
+    //             strategy.maxBorrowCollatRatio(),
+    //             strategy.daiBorrowCollatRatio()
+    //         );
+    //         vm_std_cheats.stopPrank();
+    //     }
 
-        // withdrawal
-        for (uint256 i = 1; i < 10; i++) {
-            console.log(i);
-            utils.strategyStatus(vault, strategy);
-            vm_std_cheats.prank(user);
-            vault.withdraw(uint256(_amount / 10), user, 10_000);
-            assertGe(want.balanceOf(user), (balanceBefore * i) / 10);
-        }
+    //     // withdrawal
+    //     for (uint256 i = 1; i < 10; i++) {
+    //         console.log(i);
+    //         utils.strategyStatus(vault, strategy);
+    //         vm_std_cheats.prank(user);
+    //         vault.withdraw(uint256(_amount / 10), user, 10_000);
+    //         assertGe(want.balanceOf(user), (balanceBefore * i) / 10);
+    //     }
 
-        skip(1);
-        vm_std_cheats.prank(strategist);
-        strategy.harvest();
-        skip(6 hours);
-        vm_std_cheats.prank(user);
-        vault.withdraw(uint256(_amount / 10));
-        assertGt(want.balanceOf(user), balanceBefore);
-        utils.strategyStatus(vault, strategy);
-    }
+    //     skip(1);
+    //     vm_std_cheats.prank(strategist);
+    //     strategy.harvest();
+    //     skip(6 hours);
+    //     vm_std_cheats.prank(user);
+    //     vault.withdraw(uint256(_amount / 10));
+    //     assertGt(want.balanceOf(user), balanceBefore);
+    //     utils.strategyStatus(vault, strategy);
+    // }
 
     // @dev See https://github.com/gakonst/foundry/issues/871
     //      on how to fuzz enums in foundry
@@ -154,72 +154,72 @@ contract StrategyOperationsTest is StrategyFixture {
         console.log("on ", total);
     }
 
-    function testAprWithCooldown(uint256 _amount) public {
-        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
-        tip(address(want), address(user), _amount);
+    // function testAprWithCooldown(uint256 _amount) public {
+    //     vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
+    //     tip(address(want), address(user), _amount);
 
-        // Don't sell stkAave, cool it down
-        vm_std_cheats.startPrank(gov);
-        strategy.setRewardBehavior(
-            Strategy.SwapRouter(1),
-            false,
-            true,
-            strategy.minRewardToSell(),
-            strategy.maxStkAavePriceImpactBps(),
-            strategy.stkAaveToAaveSwapFee(),
-            strategy.aaveToWethSwapFee(),
-            strategy.wethToWantSwapFee()
-        );
-        vm_std_cheats.stopPrank();
+    //     // Don't sell stkAave, cool it down
+    //     vm_std_cheats.startPrank(gov);
+    //     strategy.setRewardBehavior(
+    //         Strategy.SwapRouter(1),
+    //         false,
+    //         true,
+    //         strategy.minRewardToSell(),
+    //         strategy.maxStkAavePriceImpactBps(),
+    //         strategy.stkAaveToAaveSwapFee(),
+    //         strategy.aaveToWethSwapFee(),
+    //         strategy.wethToWantSwapFee()
+    //     );
+    //     vm_std_cheats.stopPrank();
 
-        // harvest
-        skip(1);
-        vm_std_cheats.prank(strategist);
-        strategy.harvest();
-        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+    //     // harvest
+    //     skip(1);
+    //     vm_std_cheats.prank(strategist);
+    //     strategy.harvest();
+    //     assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
 
-        skip(7 days);
-        vm_std_cheats.prank(gov);
-        vault.revokeStrategy(address(strategy));
-        vm_std_cheats.prank(strategist);
-        strategy.harvest();
+    //     skip(7 days);
+    //     vm_std_cheats.prank(gov);
+    //     vault.revokeStrategy(address(strategy));
+    //     vm_std_cheats.prank(strategist);
+    //     strategy.harvest();
 
-        skip(101 days / 10);
+    //     skip(101 days / 10);
 
-        vm_std_cheats.prank(strategist);
-        strategy.harvest();
-        int256 apr = ((int256(want.balanceOf(address(vault))) -
-            int256(_amount)) *
-            52 *
-            100) / int256(_amount);
-        uint256 total = _amount / (10**vault.decimals());
-        console.log("APR:");
-        console.logInt(apr);
-        console.log("on ", total);
-    }
+    //     vm_std_cheats.prank(strategist);
+    //     strategy.harvest();
+    //     int256 apr = ((int256(want.balanceOf(address(vault))) -
+    //         int256(_amount)) *
+    //         52 *
+    //         100) / int256(_amount);
+    //     uint256 total = _amount / (10**vault.decimals());
+    //     console.log("APR:");
+    //     console.logInt(apr);
+    //     console.log("on ", total);
+    // }
 
-    function testHarvestAfterLongIdlePeriod(uint256 _amount) public {
-        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
-        tip(address(want), address(user), _amount);
+    // function testHarvestAfterLongIdlePeriod(uint256 _amount) public {
+    //     vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
+    //     tip(address(want), address(user), _amount);
 
-        // Deposit to the vault
-        actions.userDeposit(user, vault, want, _amount);
+    //     // Deposit to the vault
+    //     actions.userDeposit(user, vault, want, _amount);
 
-        // harvest
-        skip(1);
-        vm_std_cheats.prank(strategist);
-        strategy.harvest();
-        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+    //     // harvest
+    //     skip(1);
+    //     vm_std_cheats.prank(strategist);
+    //     strategy.harvest();
+    //     assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
 
-        utils.strategyStatus(vault, strategy);
-        skip(26 weeks);
-        utils.strategyStatus(vault, strategy);
+    //     utils.strategyStatus(vault, strategy);
+    //     skip(26 weeks);
+    //     utils.strategyStatus(vault, strategy);
 
-        vm_std_cheats.prank(strategist);
-        strategy.harvest();
+    //     vm_std_cheats.prank(strategist);
+    //     strategy.harvest();
 
-        utils.strategyStatus(vault, strategy);
-    }
+    //     utils.strategyStatus(vault, strategy);
+    // }
 
     function testEmergencyExit(uint256 _amount) public {
         vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);

--- a/src/test/StrategyOperation.t.sol
+++ b/src/test/StrategyOperation.t.sol
@@ -29,9 +29,7 @@ contract StrategyOperationsTest is StrategyFixture {
 
     /// Test Operations
     function testOperation(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), address(user), _amount);
 
         // Deposit to the vault
@@ -58,9 +56,7 @@ contract StrategyOperationsTest is StrategyFixture {
     }
 
     function testWithdraw(uint256 _amount, bool _isFlashLoanActive) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), address(user), _amount);
 
         // Deposit to the vault
@@ -115,9 +111,7 @@ contract StrategyOperationsTest is StrategyFixture {
     // @dev See https://github.com/gakonst/foundry/issues/871
     //      on how to fuzz enums in foundry
     function testApr(uint256 _amount, uint8 _swapRouter) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         vm_std_cheats.assume(_swapRouter <= 2);
         Strategy.SwapRouter sr = Strategy.SwapRouter(_swapRouter);
         tip(address(want), address(user), _amount);
@@ -161,9 +155,7 @@ contract StrategyOperationsTest is StrategyFixture {
     }
 
     function testAprWithCooldown(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), address(user), _amount);
 
         // Don't sell stkAave, cool it down
@@ -207,9 +199,7 @@ contract StrategyOperationsTest is StrategyFixture {
     }
 
     function testHarvestAfterLongIdlePeriod(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), address(user), _amount);
 
         // Deposit to the vault
@@ -232,9 +222,7 @@ contract StrategyOperationsTest is StrategyFixture {
     }
 
     function testEmergencyExit(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), address(user), _amount);
 
         // Deposit to the vault
@@ -256,9 +244,7 @@ contract StrategyOperationsTest is StrategyFixture {
     function testIncreaseDebtRatio(uint256 _amount, uint16 _startingDebtRatio)
         public
     {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         vm_std_cheats.assume(
             _startingDebtRatio >= 100 && _startingDebtRatio < 10_000
         );
@@ -292,9 +278,7 @@ contract StrategyOperationsTest is StrategyFixture {
     function testDecreaseDebtRatio(uint256 _amount, uint16 _endingDebtRatio)
         public
     {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         vm_std_cheats.assume(
             _endingDebtRatio >= 100 && _endingDebtRatio < 10_000
         );
@@ -327,9 +311,7 @@ contract StrategyOperationsTest is StrategyFixture {
     }
 
     function testLargeDeleverage(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), address(user), _amount);
 
         // Deposit to the vault and harvest
@@ -358,9 +340,7 @@ contract StrategyOperationsTest is StrategyFixture {
     }
 
     function testLargerDeleverage(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), address(user), _amount);
 
         // Deposit to the vault and harvest
@@ -391,9 +371,7 @@ contract StrategyOperationsTest is StrategyFixture {
     }
 
     function testSweep(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), address(user), _amount);
 
         // Strategy want token doesn't work
@@ -425,9 +403,7 @@ contract StrategyOperationsTest is StrategyFixture {
     }
 
     function testTriggers(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), address(user), _amount);
 
         // Deposit to the vault and harvest
@@ -443,9 +419,7 @@ contract StrategyOperationsTest is StrategyFixture {
     }
 
     function testTend(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), address(user), _amount);
 
         // Deposit to the vault and harvest

--- a/src/test/StrategyRestrictedFn.t.sol
+++ b/src/test/StrategyRestrictedFn.t.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.12;
+
+import {StrategyFixture} from "./utils/StrategyFixture.sol";
+
+contract StrategyRestrictedFn is StrategyFixture {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    function testRestrictedFnUser(uint256 _amount) public {
+        // TODO: add all the external functions that should not be callable by a user (if any)
+        // vm_std_cheats.expectRevert(!authorized);
+        // vm_std_cheats.prank(user);
+        // strategy.setter(arg1, arg2);
+        // NO FUNCTIONS THAT CHANGE STRATEGY BEHAVIOR SHOULD BE CALLABLE FROM A USER
+        // thus, this may not be used
+        // TODO: add all the external functions that should be callably by a user (if any)
+        // vm_std_cheats.prank(user);
+        // strategy.setter(arg1, arg2);
+    }
+
+    function testRestrictedFnManagement(uint256 _amount) public {
+        // ONLY FUNCTIONS THAT DO NOT HAVE RUG POTENTIAL SHOULD BE CALLABLE BY MANAGEMENT
+        // (e.g. a change of 3rd party contract => rug potential)
+        // (e.g. a change in leverage ratio => no rug potential)
+        // TODO: add all the external functions that should not be callable by management (if any)
+        // vm_std_cheats.expectRevert(!authorized);
+        // vm_std_cheats.prank(management);
+        // strategy.setter(arg1, arg2);
+        // Functions that are required to unwind a strategy should go be callable by management
+        // TODO: add all the external functions that should be callably by management (if any)
+        // vm_std_cheats.prank(management);
+        // strategy.setter(arg1, arg2);
+    }
+
+    function testRestrictedFnGovernance(uint256 _amount) public {
+        // OPTIONAL: No functions are required to not be callable from governance so this may not be used
+        // TODO: add all the external functions that should not be callable by governance (if any)
+        // vm_std_cheats.expectRevert(!authorized);
+        // vm_std_cheats.prank(gov);
+        // strategy.setter(arg1, arg2);
+        // All setter functions should be callable by governance
+        // TODO: add all the external functions that should be callably by governance (if any)
+        // vm_std_cheats.prank(gov);
+        // strategy.setter(arg1, arg2);
+    }
+}

--- a/src/test/StrategyRevoke.t.sol
+++ b/src/test/StrategyRevoke.t.sol
@@ -10,9 +10,7 @@ contract StrategyRevokeTest is StrategyFixture {
     }
 
     function testRevokeStrategyFromVault(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), address(user), _amount);
 
         // Deposit to the vault and harvest
@@ -32,9 +30,7 @@ contract StrategyRevokeTest is StrategyFixture {
     }
 
     function testRevokeStrategyFromStrategy(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), address(user), _amount);
 
         actions.userDeposit(user, vault, want, _amount);
@@ -52,9 +48,7 @@ contract StrategyRevokeTest is StrategyFixture {
     }
 
     function testRevokeWithProfit(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), address(user), _amount);
 
         actions.userDeposit(user, vault, want, _amount);

--- a/src/test/StrategyRevoke.t.sol
+++ b/src/test/StrategyRevoke.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.12;
 
 import {StrategyFixture} from "./utils/StrategyFixture.sol";
+import "forge-std/console.sol";
 
 contract StrategyRevokeTest is StrategyFixture {
     function setUp() public override {
@@ -9,39 +10,68 @@ contract StrategyRevokeTest is StrategyFixture {
     }
 
     function testRevokeStrategyFromVault(uint256 _amount) public {
-        vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), address(user), _amount);
 
         // Deposit to the vault and harvest
-        vm_std_cheats.prank(user);
-        want.approve(address(vault), _amount);
-        vm_std_cheats.prank(user);
-        vault.deposit(_amount);
+        actions.userDeposit(user, vault, want, _amount);
         skip(1);
+        vm_std_cheats.prank(gov);
         strategy.harvest();
-        assertEq(strategy.estimatedTotalAssets(), _amount);
 
-        // In order to pass these tests, you will need to implement prepareReturn.
-        // TODO: uncomment the following lines.
-        // vault.revokeStrategy(address(strategy));
-        // skip(1);
-        // strategy.harvest();
-        // assertEq(want.balanceOf(address(vault)), _amount);
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+
+        vm_std_cheats.prank(gov);
+        vault.revokeStrategy(address(strategy));
+        skip(1);
+        vm_std_cheats.prank(gov);
+        strategy.harvest();
+        assertRelApproxEq(want.balanceOf(address(vault)), _amount, DELTA);
     }
 
     function testRevokeStrategyFromStrategy(uint256 _amount) public {
-        vm_std_cheats.assume(_amount > 0.1 ether && _amount < 10e18);
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), address(user), _amount);
 
-        vm_std_cheats.prank(user);
-        want.approve(address(vault), _amount);
-        vm_std_cheats.prank(user);
-        vault.deposit(_amount);
+        actions.userDeposit(user, vault, want, _amount);
         skip(1);
+        vm_std_cheats.prank(gov);
         strategy.harvest();
-        assertEq(strategy.estimatedTotalAssets(), _amount);
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
 
+        vm_std_cheats.prank(gov);
         strategy.setEmergencyExit();
         skip(1);
+        vm_std_cheats.prank(gov);
         strategy.harvest();
-        assertEq(want.balanceOf(address(vault)), _amount);
+        assertRelApproxEq(want.balanceOf(address(vault)), _amount, DELTA);
+    }
+
+    function testRevokeWithProfit(uint256 _amount) public {
+        vm_std_cheats.assume(
+            _amount > 0.1 ether && _amount < 100_000_000 ether
+        );
+        tip(address(want), address(user), _amount);
+
+        actions.userDeposit(user, vault, want, _amount);
+        skip(1);
+        vm_std_cheats.prank(gov);
+        strategy.harvest();
+        assertRelApproxEq(strategy.estimatedTotalAssets(), _amount, DELTA);
+
+        uint256 profitAmount = (_amount * 5) / 100; // generating a 5% profit
+        actions.generateProfit(strategy, whale, profitAmount);
+
+        // Revoke strategy
+        vm_std_cheats.prank(gov);
+        vault.revokeStrategy(address(strategy));
+        skip(1);
+        vm_std_cheats.prank(gov);
+        strategy.harvest();
+        checks.checkRevokedStrategy(vault, strategy);
     }
 }

--- a/src/test/StrategyShutdown.t.sol
+++ b/src/test/StrategyShutdown.t.sol
@@ -12,9 +12,7 @@ contract StrategyShutdownTest is StrategyFixture {
     }
 
     function testShutdown(uint256 _amount) public {
-        vm_std_cheats.assume(
-            _amount > 0.1 ether && _amount < 100_000_000 ether
-        );
+        vm_std_cheats.assume(_amount > minFuzzAmt && _amount < maxFuzzAmt);
         tip(address(want), address(user), _amount);
 
         // Deposit to the vault and harvest

--- a/src/test/utils/Actions.sol
+++ b/src/test/utils/Actions.sol
@@ -12,6 +12,8 @@ import {ILendingPoolAddressesProvider} from "../../interfaces/aave/ILendingPoolA
 import {IProtocolDataProvider} from "../../interfaces/aave/IProtocolDataProvider.sol";
 import {Strategy} from "../../Strategy.sol";
 
+import "forge-std/console.sol";
+
 contract Actions is ExtendedDSTest, stdCheats {
     Vm public constant vm_std_cheats =
         Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
@@ -49,5 +51,11 @@ contract Actions is ExtendedDSTest, stdCheats {
         IERC20(want).approve(address(lp), type(uint256).max);
         vm_std_cheats.prank(_whale);
         lp.deposit(want, _amount, address(_strategy), 0);
+    }
+
+    function generateLoss(Strategy _strategy, uint256 _amount) public {
+        address aToken = address(_strategy.aToken());
+        vm_std_cheats.prank(address(_strategy));
+        IERC20(aToken).transfer(aToken, _amount);
     }
 }

--- a/src/test/utils/Actions.sol
+++ b/src/test/utils/Actions.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.12;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IVault} from "../../interfaces/Vault.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {ExtendedDSTest} from "./ExtendedDSTest.sol";
+import {stdCheats} from "forge-std/stdlib.sol";
+
+import {ILendingPool} from "../../interfaces/aave/ILendingPool.sol";
+import {ILendingPoolAddressesProvider} from "../../interfaces/aave/ILendingPoolAddressesProvider.sol";
+import {IProtocolDataProvider} from "../../interfaces/aave/IProtocolDataProvider.sol";
+import {Strategy} from "../../Strategy.sol";
+
+contract Actions is ExtendedDSTest, stdCheats {
+    Vm public constant vm_std_cheats =
+        Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function userDeposit(
+        address _user,
+        IVault _vault,
+        IERC20 _want,
+        uint256 _amount
+    ) public {
+        if (_want.allowance(_user, address(_vault)) < _amount) {
+            vm_std_cheats.prank(_user);
+            _want.approve(address(_vault), type(uint256).max);
+        }
+        vm_std_cheats.prank(_user);
+        _vault.deposit(_amount);
+        assertEq(_want.balanceOf(address(_vault)), _amount);
+    }
+
+    function generateProfit(
+        Strategy _strategy,
+        address _whale,
+        uint256 _amount
+    ) public {
+        ILendingPool lp = ILendingPool(
+            ILendingPoolAddressesProvider(
+                IProtocolDataProvider(
+                    0x057835Ad21a177dbdd3090bB1CAE03EaCF78Fc6d
+                ).ADDRESSES_PROVIDER()
+            ).getLendingPool()
+        );
+        address want = address(_strategy.want());
+        tip(want, _whale, _amount);
+        vm_std_cheats.prank(_whale);
+        IERC20(want).approve(address(lp), type(uint256).max);
+        vm_std_cheats.prank(_whale);
+        lp.deposit(want, _amount, address(_strategy), 0);
+    }
+}

--- a/src/test/utils/Checks.sol
+++ b/src/test/utils/Checks.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.12;
+
+import {IVault, StrategyParams} from "../../interfaces/Vault.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {ExtendedDSTest} from "./ExtendedDSTest.sol";
+import {Strategy} from "../../Strategy.sol";
+
+contract Checks is ExtendedDSTest {
+    Vm public constant vm_std_cheats =
+        Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function checkRevokedStrategy(IVault _vault, Strategy _strategy) public {
+        StrategyParams memory status = _vault.strategies(address(_strategy));
+        assertEq(status.debtRatio, 0);
+        assertEq(status.totalDebt, 0);
+    }
+
+    function checkAccounting(
+        IVault _vault,
+        Strategy _strategy,
+        uint256 _totalGain,
+        uint256 _totalLoss,
+        uint256 _totalDebt,
+        uint256 _delta
+    ) public {
+        // inputs have to be manually calculated then checked
+        StrategyParams memory status = _vault.strategies(address(_strategy));
+        assertRelApproxEq(status.totalGain, _totalGain, _delta);
+        assertRelApproxEq(status.totalLoss, _totalLoss, _delta);
+        assertRelApproxEq(status.totalDebt, _totalDebt, _delta);
+    }
+}

--- a/src/test/utils/ExtendedDSTest.sol
+++ b/src/test/utils/ExtendedDSTest.sol
@@ -13,4 +13,26 @@ contract ExtendedDSTest is DSTest {
             fail();
         }
     }
+
+    // @dev checks whether @a is within certain percentage of @b
+    // @a actual value
+    // @b expected value
+    // solhint-disable-next-line
+    function assertRelApproxEq(
+        uint256 a,
+        uint256 b,
+        uint256 maxPercentDelta
+    ) internal virtual {
+        uint256 delta = a > b ? a - b : b - a;
+        uint256 maxRelDelta = b / maxPercentDelta;
+
+        if (delta > maxRelDelta) {
+            emit log("Error: a ~= b not satisfied [uint]");
+            emit log_named_uint("  Expected", b);
+            emit log_named_uint("    Actual", a);
+            emit log_named_uint(" Max Delta", maxRelDelta);
+            emit log_named_uint("     Delta", delta);
+            fail();
+        }
+    }
 }

--- a/src/test/utils/StrategyFixture.sol
+++ b/src/test/utils/StrategyFixture.sol
@@ -73,8 +73,10 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
         );
 
         // do here additional setup
-        vm_std_cheats.prank(gov);
+        vm_std_cheats.startPrank(gov);
+        vault.setManagementFee(0);
         vault.setDepositLimit(type(uint256).max);
+        vm_std_cheats.stopPrank();
     }
 
     // Deploys a vault

--- a/src/test/utils/StrategyFixture.sol
+++ b/src/test/utils/StrategyFixture.sol
@@ -26,6 +26,7 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
 
     IVault public vault;
     Strategy public strategy;
+    LevAaveFactory public levAaveFactory;
     IERC20 public weth;
     IERC20 public want;
 
@@ -47,7 +48,7 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
     // @dev maximum amount of want tokens deposited based on @maxDollarNotional
     uint256 public maxFuzzAmt;
     // @dev maximum dollar amount of tokens to be deposited
-    uint256 public maxDollarNotional = 1_000_000;
+    uint256 public maxDollarNotional = 49_000_000;
     uint256 public constant DELTA = 10**5;
 
     mapping(string => address) tokenAddrs;
@@ -65,7 +66,7 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
 
         _setTokenPrices();
         _setTokenAddrs();
-        string memory token = "DAI"; // is this meant to be WETH?
+        string memory token = "DAI";
         weth = IERC20(tokenAddrs["WETH"]);
         want = IERC20(tokenAddrs[token]);
 
@@ -158,8 +159,7 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
 
     // @dev Deploys a strategy
     function deployStrategy(address _vault) public returns (address) {
-        LevAaveFactory _levAaveFactory = new LevAaveFactory(_vault);
-        address _strategy = _levAaveFactory.original();
+        address _strategy = levAaveFactory.original();
 
         return address(_strategy);
     }
@@ -200,6 +200,9 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
             _guardian,
             _management
         );
+
+        vm_std_cheats.prank(_strategist);
+        levAaveFactory = LevAaveFactory(deployLevAaveFactory(address(vault)));
 
         vm_std_cheats.prank(_strategist);
         _strategy = deployStrategy(_vault);

--- a/src/test/utils/StrategyFixture.sol
+++ b/src/test/utils/StrategyFixture.sol
@@ -73,6 +73,18 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
             strategist
         );
 
+        vm_std_cheats.label(address(vault), "Vault");
+        vm_std_cheats.label(address(strategy), "Strategy");
+        vm_std_cheats.label(address(want), "Want");
+        vm_std_cheats.label(gov, "Gov");
+        vm_std_cheats.label(user, "User");
+        vm_std_cheats.label(whale, "Whale");
+        vm_std_cheats.label(rewards, "Rewards");
+        vm_std_cheats.label(guardian, "Guardian");
+        vm_std_cheats.label(management, "Management");
+        vm_std_cheats.label(strategist, "Strategist");
+        vm_std_cheats.label(keeper, "Keeper");
+
         // do here additional setup
         vm_std_cheats.startPrank(gov);
         vault.setManagementFee(0);

--- a/src/test/utils/StrategyFixture.sol
+++ b/src/test/utils/StrategyFixture.sol
@@ -48,8 +48,10 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
     // @dev maximum amount of want tokens deposited based on @maxDollarNotional
     uint256 public maxFuzzAmt;
     // @dev maximum dollar amount of tokens to be deposited
-    uint256 public maxDollarNotional = 49_000_000;
+    uint256 public constant maxDollarNotional = 1_000_000;
+    uint256 public constant bigDollarNotional = 49_000_000;
     uint256 public constant DELTA = 10**5;
+    uint256 public bigAmount;
 
     mapping(string => address) tokenAddrs;
     mapping(string => uint256) tokenPrices;
@@ -85,6 +87,9 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
         minFuzzAmt = 10**vault.decimals() / 10;
         maxFuzzAmt =
             uint256(maxDollarNotional / tokenPrices[token]) *
+            10**vault.decimals();
+        bigAmount =
+            uint256(bigDollarNotional / tokenPrices[token]) *
             10**vault.decimals();
 
         vm_std_cheats.label(address(vault), "Vault");
@@ -158,7 +163,7 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
     }
 
     // @dev Deploys a strategy
-    function deployStrategy(address _vault) public returns (address) {
+    function deployStrategy() public returns (address) {
         address _strategy = levAaveFactory.original();
 
         return address(_strategy);
@@ -205,7 +210,7 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
         levAaveFactory = LevAaveFactory(deployLevAaveFactory(address(vault)));
 
         vm_std_cheats.prank(_strategist);
-        _strategy = deployStrategy(_vault);
+        _strategy = deployStrategy();
         strategy = Strategy(_strategy);
 
         vm_std_cheats.prank(_strategist);

--- a/src/test/utils/StrategyFixture.sol
+++ b/src/test/utils/StrategyFixture.sol
@@ -8,6 +8,9 @@ import {ExtendedDSTest} from "./ExtendedDSTest.sol";
 import {stdCheats} from "forge-std/stdlib.sol";
 import {Vm} from "forge-std/Vm.sol";
 import {IVault} from "../../interfaces/Vault.sol";
+import {Actions} from "./Actions.sol";
+import {Checks} from "./Checks.sol";
+import {Utils} from "./Utils.sol";
 
 // NOTE: if the name of the strat or file changes this needs to be updated
 import {Strategy} from "../../Strategy.sol";
@@ -27,40 +30,51 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
 
     // we use custom names that are unlikely to cause collisions so this contract
     // can be inherited easily
-    Vm public constant vm_std_cheats = Vm(address(uint160(uint256(keccak256('hevm cheat code')))));
+    Vm public constant vm_std_cheats =
+        Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
 
-    // NOTE: feel free change these vars to adjust for your strategy testing
-    IERC20 public constant DAI =
-        IERC20(0x6B175474E89094C44Da98b954EedeAC495271d0F);
-    IERC20 public constant WETH =
-        IERC20(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
-    address public whale = 0x5d3a536E4D6DbD6114cc1Ead35777bAB948E3643;
-    address public user = address(1337);
-    address public strategist = address(1);
-    uint256 public constant WETH_AMT = 10**18;
+    address public gov = 0xFEB4acf3df3cDEA7399794D0869ef76A6EfAff52;
+    address public user = address(1);
+    address public whale = address(2);
+    address public rewards = address(3);
+    address public guardian = address(4);
+    address public management = address(5);
+    address public strategist = address(6);
+    address public keeper = address(7);
+
+    uint256 public constant DELTA = 10**5;
+
+    mapping(string => address) tokenAddrs;
+
+    // utils
+    Actions actions;
+    Checks checks;
+    Utils utils;
 
     function setUp() public virtual {
-        weth = WETH;
+        actions = new Actions();
+        checks = new Checks();
+        utils = new Utils();
 
-        // replace with your token
-        want = DAI;
+        _setTokenAddrs();
+        weth = IERC20(tokenAddrs["WETH"]);
+        want = IERC20(tokenAddrs["DAI"]);
 
         deployVaultAndStrategy(
             address(want),
-            address(this),
-            address(this),
+            gov,
+            rewards,
             "",
             "",
-            address(this),
-            address(this),
-            address(this),
+            guardian,
+            management,
+            keeper,
             strategist
         );
 
         // do here additional setup
+        vm_std_cheats.prank(gov);
         vault.setDepositLimit(type(uint256).max);
-        tip(address(want), address(user), 10000e18);
-        vm_std_cheats.deal(user, 10_000 ether);
     }
 
     // Deploys a vault
@@ -73,9 +87,11 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
         address _guardian,
         address _management
     ) public returns (address) {
+        vm_std_cheats.prank(gov);
         address _vault = deployCode(vaultArtifact);
         vault = IVault(_vault);
 
+        vm_std_cheats.prank(gov);
         vault.initialize(
             _token,
             _gov,
@@ -108,9 +124,11 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
         address _keeper,
         address _strategist
     ) public returns (address _vault, address _strategy) {
+        vm_std_cheats.prank(gov);
         _vault = deployCode(vaultArtifact);
         vault = IVault(_vault);
 
+        vm_std_cheats.prank(gov);
         vault.initialize(
             _token,
             _gov,
@@ -128,6 +146,17 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
         vm_std_cheats.prank(_strategist);
         strategy.setKeeper(_keeper);
 
+        vm_std_cheats.prank(gov);
         vault.addStrategy(_strategy, 10_000, 0, type(uint256).max, 1_000);
+    }
+
+    function _setTokenAddrs() internal {
+        tokenAddrs["WBTC"] = 0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599;
+        tokenAddrs["YFI"] = 0x0bc529c00C6401aEF6D220BE8C6Ea1667F6Ad93e;
+        tokenAddrs["WETH"] = 0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2;
+        tokenAddrs["LINK"] = 0x514910771AF9Ca656af840dff83E8264EcF986CA;
+        tokenAddrs["USDT"] = 0xdAC17F958D2ee523a2206206994597C13D831ec7;
+        tokenAddrs["DAI"] = 0x6B175474E89094C44Da98b954EedeAC495271d0F;
+        tokenAddrs["USDC"] = 0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48;
     }
 }

--- a/src/test/utils/StrategyFixture.sol
+++ b/src/test/utils/StrategyFixture.sol
@@ -14,12 +14,13 @@ import {Utils} from "./Utils.sol";
 
 // NOTE: if the name of the strat or file changes this needs to be updated
 import {Strategy} from "../../Strategy.sol";
+import {LevAaveFactory} from "../../LevAaveFactory.sol";
 
 // Artifact paths for deploying from the deps folder, assumes that the command is run from
 // the project root.
 string constant vaultArtifact = "artifacts/Vault.json";
 
-// Base fixture deploying Vault
+// @dev Base fixture deploying Vault
 contract StrategyFixture is ExtendedDSTest, stdCheats {
     using SafeERC20 for IERC20;
 
@@ -79,7 +80,7 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
         vm_std_cheats.stopPrank();
     }
 
-    // Deploys a vault
+    // @dev Deploys a vault
     function deployVault(
         address _token,
         address _gov,
@@ -107,14 +108,24 @@ contract StrategyFixture is ExtendedDSTest, stdCheats {
         return address(vault);
     }
 
-    // Deploys a strategy
+    // @dev Deploys a strategy
     function deployStrategy(address _vault) public returns (address) {
         Strategy _strategy = new Strategy(_vault);
 
         return address(_strategy);
     }
 
-    // Deploys a vault and strategy attached to vault
+    // @dev Deploys levAaveFactory
+    function deployLevAaveFactory(address _vault)
+        public
+        returns (address _levAaveFactory)
+    {
+        LevAaveFactory _levAaveFactory = new LevAaveFactory(_vault);
+
+        return address(_levAaveFactory);
+    }
+
+    // @dev Deploys a vault and strategy attached to vault
     function deployVaultAndStrategy(
         address _token,
         address _gov,

--- a/src/test/utils/Utils.sol
+++ b/src/test/utils/Utils.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: AGPL-3.0
+pragma solidity ^0.8.12;
+
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import {IVault, StrategyParams} from "../../interfaces/Vault.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {ExtendedDSTest} from "./ExtendedDSTest.sol";
+import {Strategy} from "../../Strategy.sol";
+import "forge-std/console.sol";
+
+contract Utils is ExtendedDSTest {
+    Vm public constant vm_std_cheats =
+        Vm(address(uint160(uint256(keccak256("hevm cheat code")))));
+
+    function strategyStatus(IVault _vault, Strategy _strategy) public {
+        StrategyParams memory status = _vault.strategies(address(_strategy));
+        (uint256 lend, uint256 borrow) = _strategy.getCurrentPosition();
+        uint256 ratio = _strategy.getCurrentCollatRatio();
+
+        console.log("--- Strategy", _strategy.name(), " ---");
+        console.log("Performance fee", status.performanceFee);
+        console.log("Debt Ratio", status.debtRatio);
+        console.log("Total Debt", toUnits(_vault, status.totalDebt));
+        console.log("Total Gain", toUnits(_vault, status.totalGain));
+        console.log("Total Loss", toUnits(_vault, status.totalLoss));
+        console.log(
+            "Estimated Total Assets",
+            toUnits(_vault, _strategy.estimatedTotalAssets())
+        );
+        console.log(
+            "Estimated Total Reward",
+            toUnits(_vault, _strategy.estimatedRewardsInWant())
+        );
+        console.log(
+            "Loose Want",
+            toUnits(_vault, _strategy.want().balanceOf(address(_strategy)))
+        );
+        console.log("Current Lend", toUnits(_vault, lend));
+        console.log("Current Borrow", toUnits(_vault, borrow));
+        console.log("Current LTV Ratio", (ratio * 10000) / 10**18);
+        console.log(
+            "Target LTV Ratio",
+            (_strategy.targetCollatRatio() * 10000) / 10**18
+        );
+        console.log(
+            "Max LTV Ratio",
+            (_strategy.maxCollatRatio() * 10000) / 10**18
+        );
+        console.log(
+            "Max Borrow LTV Ratio",
+            (_strategy.maxBorrowCollatRatio() * 10000) / 10**18
+        );
+    }
+
+    function toUnits(IVault _vault, uint256 _amount)
+        internal
+        returns (uint256)
+    {
+        return (_amount / (10**_vault.decimals())) * 10000;
+    }
+}

--- a/src/test/utils/Utils.sol
+++ b/src/test/utils/Utils.sol
@@ -37,6 +37,8 @@ contract Utils is ExtendedDSTest {
         );
         console.log("Current Lend", toUnits(_vault, lend));
         console.log("Current Borrow", toUnits(_vault, borrow));
+        // decimals expressed as 5 digit unit
+        // 10000 = 1
         console.log("Current LTV Ratio", (ratio * 10000) / 10**18);
         console.log(
             "Target LTV Ratio",
@@ -56,6 +58,6 @@ contract Utils is ExtendedDSTest {
         internal
         returns (uint256)
     {
-        return (_amount / (10**_vault.decimals())) * 10000;
+        return (_amount / (10**_vault.decimals()));
     }
 }


### PR DESCRIPTION
Fixes #1 

Creating PR early to get feedback and track test changes. Some tests fail in the original brownie repo and also fail in foundry. Some tests fail only in foundry (usually in the fuzzing on the nth iteration, not on the first iteration).

I will work on porting all tests across first, then will take a look at fixing the tests that fail in foundry but not in brownie. Tests that fail in both will be left out. I will also port changes in the fixture back to foundry_strategy_mix, as I believe they will be beneficial to people creating new strategies.

Tests
- [x] airdrop
- [x] clone
- [x] deleverage
- [x] harvests
- [x] healthcheck
- [x] migration 
- [x] operation 
- [x] revoke
- [x] shutdown

Note:
manual_operation & restricted_fn are commented out. Included copies in the tests. Left out ape_tax as it is skipped. 

Known Issues
- Testing against WETH (as want) results in an error in LendingPool during userDeposit
- Some tests fail (some were failing in original repo, some failing exclusively in this repo). To reproduce, pin block to 14000000 and run tests. 

Test against:
- [x] DAI

Some notes:
- `assertRelApproxEq` is modeled after pytest's `approx`. Some `assertEq` checks had to be replaced with `assertRelApproxEq` as large number arithmetic is less precise in python than it is in solidity when we operate on `uint256`s.
- any numbers represented as decimals in python (e.g. percentages that are printed out) will be represented as an integer between 0 and 10000 in solidity. 

Will consider doing a write-up of the experience afterwards. May help foundry team understand challenges + help yearn people move across to foundry. 